### PR TITLE
Victor's version of swiftsim_pr 

### DIFF
--- a/ToDo
+++ b/ToDo
@@ -4,3 +4,27 @@ new particle query algorithm
 2) distribute halo in blocks
 3) compute location of halo using queried particles
 4) guess target node of unqueried particles, fetch particles to local buffer (can have a guessed buffer first)
+
+Victor: 
+
+1) Update TracerIndex when Subhalo_t::KickNullParticles is called. If particles 
+   more bound than the tracer get removed from the simulation, the value of 
+   TracerIndex should be lowered to reflect the updated particle array.
+2) Different particle limits: N_min_collisionless and N_min_total. Currently, 
+   N_min_collisionless = N_min_total = 20
+3) Merging criteria. Implement relative criteria. Also work with specified tracers 
+   (**dont use gas particles**). Use more than 1 most bound particle for the satellites 
+   (check if they are orphans)
+4) Diagnostic plots, with subfind and other halo finders as references. ROB
+5) Auto-testing
+6) Remove parameters that are read in from swiftsim snapshots (including units.)
+7) Implement baryonic softening.
+8)  Faster loading of subhaloes via a hash table. Currently outputting unsorted subhaloes.
+   Do it in the same way as swift does (top cell)? In TrackId ordering?
+9) Identify HBT information that could help speed up SOAP. See above.
+10) Add additional box wrapping after adding CoM offset with respect to a reference particle.
+    e.g. ParticleSnapshot_t::AveragePosition and AveragePosition (defined in snapshot.cpp)
+11) Update OldMostboundParticle using the TracerIndex.
+
+John:
+1) Check why merging fails in certain cases, within DMO runs.

--- a/src/datatypes.h
+++ b/src/datatypes.h
@@ -6,6 +6,7 @@
 using namespace std;
 #include <array>
 #include <vector>
+
 // #include <memory>
 #ifdef DM_ONLY
 #undef UNBIND_WITH_THERMAL_ENERGY
@@ -64,7 +65,7 @@ typedef HBTReal HBTMassType;
 #define MPI_HBT_MASS MPI_HBT_REAL
 #endif
 
-// the user should ganrantee that HBTInt can at least hold NP_DM
+// The user should guarantee that HBTInt can at least hold NP_DM
 #ifdef HBT_INT8
 typedef long HBTInt;
 #define HBTIFMT "%ld"
@@ -74,6 +75,13 @@ typedef int HBTInt;
 #define HBTIFMT "%d"
 #define MPI_HBT_INT MPI_INT
 #endif
+
+/* Used for reducing the TracerIndex value. Taken from https://shorturl.at/aENT2 */
+typedef pair<HBTInt, int> IndexParticleType_t;
+inline IndexParticleType_t firstIndex(IndexParticleType_t a, IndexParticleType_t b)
+{
+  return a.first < b.first ? a : b;
+}
 
 // typedef HBTReal HBTxyz[3];  //3-d pos/vel data
 /*inline void copyHBTxyz(HBTxyz & dest, const HBTxyz & src)

--- a/src/io/swiftsim_io.cpp
+++ b/src/io/swiftsim_io.cpp
@@ -665,6 +665,7 @@ void SwiftSimReader_t::LoadSnapshot(MpiWorker_t &world, int snapshotId, vector<P
 
   /* Assign the box size read in from the Header */
   HBTConfig.BoxSize = Header.BoxSize;
+  HBTConfig.BoxHalf = HBTConfig.BoxSize / 2;
 
   /* Use the softening values we read in from the Header */
   HBTConfig.SofteningHalo = Header.DM_comoving_softening;

--- a/src/io/swiftsim_io.cpp
+++ b/src/io/swiftsim_io.cpp
@@ -23,7 +23,7 @@ void create_SwiftSimHeader_MPI_type(MPI_Datatype &dtype)
 {
   /*to create the struct data type for communication*/
   SwiftSimHeader_t p;
-#define NumAttr 14
+#define NumAttr 18
   MPI_Datatype oldtypes[NumAttr];
   int blockcounts[NumAttr];
   MPI_Aint offsets[NumAttr], origin, extent;
@@ -53,6 +53,10 @@ void create_SwiftSimHeader_MPI_type(MPI_Datatype &dtype)
   RegisterAttr(velocity_conversion, MPI_DOUBLE, 1);
   RegisterAttr(energy_conversion, MPI_DOUBLE, 1);
   RegisterAttr(NullGroupId, MPI_INTEGER, 1);
+  RegisterAttr(DM_comoving_softening, MPI_DOUBLE, 1);
+  RegisterAttr(DM_maximum_physical_softening, MPI_DOUBLE, 1);
+  RegisterAttr(baryon_comoving_softening, MPI_DOUBLE, 1);
+  RegisterAttr(baryon_maximum_physical_softening, MPI_DOUBLE, 1);
 
 #undef RegisterAttr
   assert(i <= NumAttr);

--- a/src/io/swiftsim_io.cpp
+++ b/src/io/swiftsim_io.cpp
@@ -671,6 +671,10 @@ void SwiftSimReader_t::LoadSnapshot(MpiWorker_t &world, int snapshotId, vector<P
   HBTConfig.SofteningHalo = Header.DM_comoving_softening;
   HBTConfig.MaxPhysicalSofteningHalo = Header.DM_maximum_physical_softening;
 
+  /* Update the tree parameters based on the softenings */
+  HBTConfig.TreeNodeResolution = HBTConfig.SofteningHalo * 0.1;
+  HBTConfig.TreeNodeResolutionHalf = HBTConfig.TreeNodeResolution / 2.;
+
   // Decide how many particles this MPI rank will read
   HBTInt np_total = accumulate(np_file.begin(), np_file.end(), (HBTInt)0);
   HBTInt np_local = np_total / world.size();

--- a/src/io/swiftsim_io.cpp
+++ b/src/io/swiftsim_io.cpp
@@ -661,6 +661,9 @@ void SwiftSimReader_t::LoadSnapshot(MpiWorker_t &world, int snapshotId, vector<P
 
   Cosmology.Set(Header.ScaleFactor, Header.OmegaM0, Header.OmegaLambda0);
 
+  /* Assign the box size read in from the Header */
+  HBTConfig.BoxSize = Header.BoxSize;
+
   /* Use the softening values we read in from the Header */
   HBTConfig.SofteningHalo = Header.DM_comoving_softening;
   HBTConfig.MaxPhysicalSofteningHalo = Header.DM_maximum_physical_softening;

--- a/src/subhalo.cpp
+++ b/src/subhalo.cpp
@@ -3,6 +3,7 @@
 #include <new>
 #include <numeric>
 #include <omp.h>
+#include <limits>
 
 #include "datatypes.h"
 #include "snapshot_number.h"
@@ -433,6 +434,14 @@ void Subhalo_t::CalculateShape()
 void Subhalo_t::CountParticleTypes()
 {
 #ifndef DM_ONLY
+
+  /* Used for finding TracerIndex for large (Nbound > 100) tracks */
+#pragma omp declare reduction(minPair:IndexParticleType_t : omp_out = firstIndex(omp_out, omp_in))                     \
+  initializer(omp_priv = IndexParticleType_t(numeric_limits<HBTInt>::max(), -1))
+
+  /* Initialise the value of the pair to identify specified tracer */
+  IndexParticleType_t Tracer_Index_ParticleType(numeric_limits<HBTInt>::max(), -1);
+
   for (int itype = 0; itype < TypeMax; itype++)
   {
     NboundType[itype] = 0;
@@ -444,7 +453,7 @@ void Subhalo_t::CountParticleTypes()
     {
       vector<HBTInt> nboundtype(TypeMax, 0);
       vector<float> mboundtype(TypeMax, 0.);
-#pragma omp for reduction(min : TracerIndex)
+#pragma omp for reduction(minPair : Tracer_Index_ParticleType)
       for (HBTInt i = 0; i < Nbound; i++)
       {
         auto &p = Particles[i];
@@ -456,9 +465,12 @@ void Subhalo_t::CountParticleTypes()
         /* Check whether we found a collisionless particle for the first time,
          * indicating we have reached the tentative most bound collisionless
          * tracer */
-        if (TracerIndex > Nbound)
-          if ((1 << itype) & HBTConfig.TracerParticleBitMask)
-            TracerIndex = i;
+        if (Tracer_Index_ParticleType.second == -1)           // No tracer yet
+          if ((1 << itype) & HBTConfig.TracerParticleBitMask) // Found tracer
+          {
+            Tracer_Index_ParticleType.first = i;
+            Tracer_Index_ParticleType.second = itype;
+          }
       }
 #pragma omp critical
       for (int i = 0; i < TypeMax; i++)
@@ -485,16 +497,22 @@ void Subhalo_t::CountParticleTypes()
       MboundType[itype] += p.Mass;
 
       /* Check whether we found a collisionless particle for the first time,
-       * indicating we have reached the most bound collisionless tracer */
-      if (TracerIndex > Nbound)
-        if ((1 << itype) & HBTConfig.TracerParticleBitMask)
-          TracerIndex = it - Particles.begin();
+       * indicating we have reached the tentative most bound collisionless
+       * tracer */
+      if (Tracer_Index_ParticleType.second == -1) // No tracer yet
+        if ((1 << itype) & HBTConfig.TracerParticleBitMask) // Found tracer
+        {
+          Tracer_Index_ParticleType.first = it - Particles.begin();
+          Tracer_Index_ParticleType.second = itype;
+        }
     }
   }
 
-  /* We found no collisionless tracer in this subgroup. Use most bound particle
-   * instead. */
-  TracerIndex = (TracerIndex > Nbound) ? 0 : TracerIndex;
+  // If we found no tracer in this subgroup, default to the most bound particle.
+  TracerIndex = (Tracer_Index_ParticleType.second == -1) ? 0 : Tracer_Index_ParticleType.first;
+
+  // Sanity check
+  assert(TracerIndex != numeric_limits<HBTInt>::max());
 #endif
 }
 


### PR DESCRIPTION
Merging my latest version of HBT+, which was tested on COLIBRE outputs. We should establish the minimum working version before continuing development/bug fixes. Main differences respect to master:

- Different OMP reduction fix (which one is best?)
- Automatic loading of BoxSize from swiftsim outputs
- TODO list summarising identified working points.
