### PR TITLE
Load formatter enviroment correctly

### DIFF
--- a/format.sh
+++ b/format.sh
@@ -17,6 +17,9 @@ then
   ./clang_formatting_env/bin/python3 -m pip install clang-format
 fi
 
+# Activate enviroment to enable clang-format command
+source ./clang_formatting_env/bin/activate
+
 # Formatting command
 clang=${CLANG_FORMAT_CMD:="clang-format"}
 cmd="$clang -style=file $(git ls-files '*.c' '*.h' '*.cpp')"

--- a/src/io/swiftsim_io.cpp
+++ b/src/io/swiftsim_io.cpp
@@ -211,7 +211,7 @@ void SwiftSimReader_t::ReadHeader(int ifile, SwiftSimHeader_t &header)
   ReadAttribute(file, "Parameters", "Gravity:max_physical_baryon_softening", buf);
   Header.baryon_maximum_physical_softening = stof(buf) * Header.length_conversion;
 #endif
-  
+
   H5Fclose(file);
 }
 

--- a/src/subhalo.cpp
+++ b/src/subhalo.cpp
@@ -495,7 +495,7 @@ void Subhalo_t::CountParticleTypes()
       /* Check whether we found a collisionless particle for the first time,
        * indicating we have reached the tentative most bound collisionless
        * tracer */
-      if (Tracer_Index_ParticleType.second == -1) // No tracer yet
+      if (Tracer_Index_ParticleType.second == -1)           // No tracer yet
         if ((1 << itype) & HBTConfig.TracerParticleBitMask) // Found tracer
         {
           Tracer_Index_ParticleType.first = it - Particles.begin();


### PR DESCRIPTION
The formatter enviroment was not being loaded before. This made  the command `./format.sh` not work, unless the enviroment was installed and activated prior to running it. It now loads it within the script.