### PR TITLE
Function to wrap coordinates based on boundary conditions

### DIFF
--- a/src/config_parser.h
+++ b/src/config_parser.h
@@ -169,6 +169,10 @@ inline void trim_trailing_garbage(string &s, const string &garbage_list)
 
 #define NEAREST(x)                                                                                                     \
   (((x) > HBTConfig.BoxHalf) ? ((x)-HBTConfig.BoxSize) : (((x) < -HBTConfig.BoxHalf) ? ((x) + HBTConfig.BoxSize) : (x)))
+
+#define BOX_WRAP(x)                                                                                                    \
+  (((x) > HBTConfig.BoxSize) ? ((x)-HBTConfig.BoxSize) : (((x) < -HBTConfig.BoxSize) ? ((x) + HBTConfig.BoxSize) : (x)))
+
 inline HBTReal PeriodicDistance(const HBTxyz &x, const HBTxyz &y)
 {
   HBTxyz dx;

--- a/src/config_parser.h
+++ b/src/config_parser.h
@@ -171,7 +171,7 @@ inline void trim_trailing_garbage(string &s, const string &garbage_list)
   (((x) > HBTConfig.BoxHalf) ? ((x)-HBTConfig.BoxSize) : (((x) < -HBTConfig.BoxHalf) ? ((x) + HBTConfig.BoxSize) : (x)))
 
 #define BOX_WRAP(x)                                                                                                    \
-  (((x) > HBTConfig.BoxSize) ? ((x)-HBTConfig.BoxSize) : (((x) < -HBTConfig.BoxSize) ? ((x) + HBTConfig.BoxSize) : (x)))
+  (((x) > HBTConfig.BoxSize) ? ((x)-HBTConfig.BoxSize) : (((x) < 0) ? ((x) + HBTConfig.BoxSize) : (x)))
 
 inline HBTReal PeriodicDistance(const HBTxyz &x, const HBTxyz &y)
 {

--- a/src/snapshot.cpp
+++ b/src/snapshot.cpp
@@ -107,7 +107,7 @@ void ParticleSnapshot_t::AveragePosition(HBTxyz &CoM, const HBTInt Particles[], 
     if (HBTConfig.PeriodicBoundaryOn)
     {
       sx[j] += origin[j];
-      sx[j] = BOX_WRAP(sx[j])
+      sx[j] = BOX_WRAP(sx[j]);
     }
     CoM[j] = sx[j];
   }
@@ -219,7 +219,7 @@ double AveragePosition(HBTxyz &CoM, const Particle_t Particles[], HBTInt NumPart
     if (HBTConfig.PeriodicBoundaryOn)
     {
       sx[j] += origin[j];
-      sx[j] = BOX_WRAP(sx[j])
+      sx[j] = BOX_WRAP(sx[j]);
     }
     CoM[j] = sx[j];
   }

--- a/src/snapshot.cpp
+++ b/src/snapshot.cpp
@@ -105,7 +105,10 @@ void ParticleSnapshot_t::AveragePosition(HBTxyz &CoM, const HBTInt Particles[], 
   {
     sx[j] /= msum;
     if (HBTConfig.PeriodicBoundaryOn)
+    {
       sx[j] += origin[j];
+      sx[j] = BOX_WRAP(sx[j])
+    }
     CoM[j] = sx[j];
   }
 }
@@ -214,7 +217,10 @@ double AveragePosition(HBTxyz &CoM, const Particle_t Particles[], HBTInt NumPart
   {
     sx[j] /= msum;
     if (HBTConfig.PeriodicBoundaryOn)
+    {
       sx[j] += origin[j];
+      sx[j] = BOX_WRAP(sx[j])
+    }
     CoM[j] = sx[j];
   }
   return msum;

--- a/src/subhalo_merge.cpp
+++ b/src/subhalo_merge.cpp
@@ -90,7 +90,10 @@ void SubHelper_t::BuildPosition(const Subhalo_t &sub)
     sx2[j] /= msum;
     ComovingPosition[j] = sx[j];
     if (HBTConfig.PeriodicBoundaryOn)
+    {
       ComovingPosition[j] += origin[j];
+      ComovingPosition[j] = BOX_WRAP(ComovingPosition[j]);
+    }
     sx2[j] -= sx[j] * sx[j];
   }
   ComovingSigmaR = sqrt(sx2[0] + sx2[1] + sx2[2]);

--- a/src/subhalo_unbind.cpp
+++ b/src/subhalo_unbind.cpp
@@ -194,6 +194,10 @@ public:
       sx += origin[0];
       sy += origin[1];
       sz += origin[2];
+
+      sx = BOX_WRAP(sx);
+      sy = BOX_WRAP(sy);
+      sz = BOX_WRAP(sz);
     }
     CoM[0] = sx;
     CoM[1] = sy;


### PR DESCRIPTION
Previously, HBT would not wrap coordinates after adding a shift vector to an origin point. This would lead to some subhaloes having positions outside of the box limits. 

To fix this, I created a new function that wraps coordinates, and apply it to coordinates whenever these are based on adding a shift to a reference point. 