### PR TITLE
Consider subhalos to be disrupted if they contain too few collisionless particles

### DIFF
--- a/configs/COLIBRE_test.conf
+++ b/configs/COLIBRE_test.conf
@@ -1,0 +1,39 @@
+# Configuration file used to run on 16 outputs of a (subsampled) COLIBRE 
+# simulations 
+
+[Compulsary Params]
+SnapshotPath /nobackup/dph1jch/COLIBRE/test_run/
+HaloPath /nobackup/dph1jch/COLIBRE/test_run/
+SubhaloPath hbt_output
+SnapshotFileBase colibre
+
+# These should be read in from swiftsim automatically
+BoxSize -1
+SofteningHalo -1
+MaxPhysicalSofteningHalo -1
+
+[Reader]
+# Use swift reader
+SnapshotFormat swiftsim
+GroupFileFormat swiftsim_particle_index
+
+# Which snapshots to analyse
+SnapshotIdList 4 12 20 28 36 44 52 60 68 76 84 92 100 108 116 127
+MinSnapshotIndex 0
+MaxSnapshotIndex 15
+
+[Units]
+MassInMsunh 6.81e9 # Removes h factors from the final output 
+LengthInMpch 0.681 # Removes h factors from the final output
+VelInKmS 1
+
+MaxConcurrentIO 28 # Number of cores in a cosma7 node           
+
+MinNumPartOfSub 20       # Minimum number of particles in a subhalo
+MinNumTracerPartOfSub 10 # Minimum number of particles of types specified by TracerParticleTypes in a subhalo
+
+# Optional parameters; default values are shown here
+#BoundMassPrecision 0.995
+#PeriodicBoundaryOn 1
+#SaveSubParticleProperties 0
+#TracerParticleTypes 1 4 

--- a/src/config_parser.cpp
+++ b/src/config_parser.cpp
@@ -47,6 +47,7 @@ bool Parameter_t::TrySingleValueParameter(string ParameterName, stringstream &Pa
   TrySetPar(MaxConcurrentIO);
   TrySetPar(MinSnapshotIndex);
   TrySetPar(MinNumPartOfSub);
+  TrySetPar(MinNumTracerPartOfSub);
   TrySetPar(ParticleIdRankStyle);
   TrySetPar(ParticleIdNeedHash);
   TrySetPar(SnapshotIdUnsigned);
@@ -271,6 +272,7 @@ void Parameter_t::BroadCast(MpiWorker_t &world, int root)
   _SyncAtom(MaxConcurrentIO, MPI_INT);
   _SyncAtom(MinSnapshotIndex, MPI_INT);
   _SyncAtom(MinNumPartOfSub, MPI_INT);
+  _SyncAtom(MinNumTracerPartOfSub, MPI_INT);  
   _SyncAtom(GroupParticleIdMask, MPI_LONG);
   _SyncReal(MassInMsunh);
   _SyncReal(LengthInMpch);
@@ -413,6 +415,7 @@ void Parameter_t::DumpParameters()
 
   DumpHeader("Subhalo Tracking");
   DumpPar(MinNumPartOfSub);
+  DumpPar(MinNumTracerPartOfSub);  
   if (TracerParticleTypes.size())
   {
     version_file << "TracerParticleTypes";

--- a/src/config_parser.h
+++ b/src/config_parser.h
@@ -41,6 +41,7 @@ public:
   int MaxConcurrentIO;
   int MinSnapshotIndex;
   int MinNumPartOfSub;
+  int MinNumTracerPartOfSub;  
   long GroupParticleIdMask; // only used for a peculiar gadget format.
   HBTReal MassInMsunh;
   HBTReal LengthInMpch;
@@ -90,6 +91,7 @@ public:
     MaxConcurrentIO = 10;
     MinSnapshotIndex = 0;
     MinNumPartOfSub = 20;
+    MinNumTracerPartOfSub = 20;
     GroupParticleIdMask = 0;
     MassInMsunh = 1e10;
     LengthInMpch = 1;

--- a/src/subhalo.cpp
+++ b/src/subhalo.cpp
@@ -466,7 +466,7 @@ void Subhalo_t::CountParticleTypes()
          * indicating we have reached the tentative most bound collisionless
          * tracer */
         if (Tracer_Index_ParticleType.second == -1)           // No tracer yet
-          if ((1 << itype) & HBTConfig.TracerParticleBitMask) // Found tracer
+          if (p.IsTracer()) // Found tracer
           {
             Tracer_Index_ParticleType.first = i;
             Tracer_Index_ParticleType.second = itype;
@@ -496,7 +496,7 @@ void Subhalo_t::CountParticleTypes()
        * indicating we have reached the tentative most bound collisionless
        * tracer */
       if (Tracer_Index_ParticleType.second == -1)           // No tracer yet
-        if ((1 << itype) & HBTConfig.TracerParticleBitMask) // Found tracer
+        if (p.IsTracer()) // Found tracer
         {
           Tracer_Index_ParticleType.first = it - Particles.begin();
           Tracer_Index_ParticleType.second = itype;

--- a/src/subhalo_unbind.cpp
+++ b/src/subhalo_unbind.cpp
@@ -395,7 +395,7 @@ void Subhalo_t::Unbind(const Snapshot_t &epoch)
     HBTInt Nbound_tracers = 0;
     for(HBTInt i=0; i<Nbound; i+=1) {
       const auto &p = Particles[Elist[i].pid];
-      if((1 << p.Type) & HBTConfig.TracerParticleBitMask)Nbound_tracers += 1;
+      if(p.IsTracer())Nbound_tracers += 1;
       if(Nbound_tracers >= HBTConfig.MinNumTracerPartOfSub)break; // We found enough, so no need to continue
     }
 #endif

--- a/src/subhalo_unbind.cpp
+++ b/src/subhalo_unbind.cpp
@@ -386,7 +386,21 @@ void Subhalo_t::Unbind(const Snapshot_t &epoch)
 #ifdef NO_STRIPPING
     Nbound = Nlast;
 #endif
-    if (Nbound < HBTConfig.MinNumPartOfSub) // disruption
+
+    // Count the number of bound tracer particles
+#ifdef DM_ONLY
+    // All particles are tracers in DMO runs
+    HBTInt Nbound_tracers = Nbound;
+#else
+    HBTInt Nbound_tracers = 0;
+    for(HBTInt i=0; i<Nbound; i+=1) {
+      const auto &p = Particles[Elist[i].pid];
+      if((1 << p.Type) & HBTConfig.TracerParticleBitMask)Nbound_tracers += 1;
+      if(Nbound_tracers >= HBTConfig.MinNumTracerPartOfSub)break; // We found enough, so no need to continue
+    }
+#endif
+    
+    if ((Nbound < HBTConfig.MinNumPartOfSub) || (Nbound_tracers < HBTConfig.MinNumTracerPartOfSub)) // disruption
     {
       Nbound = 1;
       Nlast = 1;


### PR DESCRIPTION
This adds a new parameter MinNumTracerPartOfSub which determines the minimum number of particles of the types specified in TracerParticleTypes which must be bound to a subhalo for it to be considered resolved. Subhalos are only resolved if they contain at least MinNumPartOfSub total particles AND at least MinNumTracerPartOfSub "tracer" type particles.
