### PR TITLE
Add MaxNumPartMerge parameter

### DIFF
--- a/configs/COLIBRE_test.conf
+++ b/configs/COLIBRE_test.conf
@@ -31,6 +31,7 @@ MaxConcurrentIO 28 # Number of cores in a cosma7 node
 
 MinNumPartOfSub 20       # Minimum number of particles in a subhalo
 MinNumTracerPartOfSub 10 # Minimum number of particles of types specified by TracerParticleTypes in a subhalo
+MaxNumPartMerge 20       # Maximum number of particles to consider when checking for mergers
 
 # Optional parameters; default values are shown here
 #BoundMassPrecision 0.995

--- a/src/config_parser.cpp
+++ b/src/config_parser.cpp
@@ -48,6 +48,7 @@ bool Parameter_t::TrySingleValueParameter(string ParameterName, stringstream &Pa
   TrySetPar(MinSnapshotIndex);
   TrySetPar(MinNumPartOfSub);
   TrySetPar(MinNumTracerPartOfSub);
+  TrySetPar(MaxNumPartMerge);
   TrySetPar(ParticleIdRankStyle);
   TrySetPar(ParticleIdNeedHash);
   TrySetPar(SnapshotIdUnsigned);
@@ -273,6 +274,7 @@ void Parameter_t::BroadCast(MpiWorker_t &world, int root)
   _SyncAtom(MinSnapshotIndex, MPI_INT);
   _SyncAtom(MinNumPartOfSub, MPI_INT);
   _SyncAtom(MinNumTracerPartOfSub, MPI_INT);  
+  _SyncAtom(MaxNumPartMerge, MPI_INT);
   _SyncAtom(GroupParticleIdMask, MPI_LONG);
   _SyncReal(MassInMsunh);
   _SyncReal(LengthInMpch);
@@ -416,6 +418,7 @@ void Parameter_t::DumpParameters()
   DumpHeader("Subhalo Tracking");
   DumpPar(MinNumPartOfSub);
   DumpPar(MinNumTracerPartOfSub);  
+  DumpPar(MaxNumPartMerge);
   if (TracerParticleTypes.size())
   {
     version_file << "TracerParticleTypes";

--- a/src/config_parser.h
+++ b/src/config_parser.h
@@ -42,6 +42,7 @@ public:
   int MinSnapshotIndex;
   int MinNumPartOfSub;
   int MinNumTracerPartOfSub;  
+  int MaxNumPartMerge;
   long GroupParticleIdMask; // only used for a peculiar gadget format.
   HBTReal MassInMsunh;
   HBTReal LengthInMpch;
@@ -92,6 +93,7 @@ public:
     MinSnapshotIndex = 0;
     MinNumPartOfSub = 20;
     MinNumTracerPartOfSub = 20;
+    MaxNumPartMerge = 20;
     GroupParticleIdMask = 0;
     MassInMsunh = 1e10;
     LengthInMpch = 1;

--- a/src/subhalo_merge.cpp
+++ b/src/subhalo_merge.cpp
@@ -8,13 +8,13 @@
 #include "snapshot_number.h"
 #include "subhalo.h"
 
-#define NumPartCoreMax 20
 #define DeltaCrit 2.
 
 void SubHelper_t::BuildPosition(const Subhalo_t &sub)
 {
-  // Compute position of a halo using the most bound NumPartCoreMax tracer
-  // type particles. If there are not enough tracers we make up the difference
+  // Compute position of a halo using min(Nbound, MaxNumPartMerge) particles.
+  // Initially we attempt to compute the position using tracer particles.
+  // If there are not enough tracers we make up the difference
   // with the most bound non-tracer particles.
   //
   // Implemented by making two passes through the halo particles looking at
@@ -22,7 +22,7 @@ void SubHelper_t::BuildPosition(const Subhalo_t &sub)
   // as soon as we've seen enough particles.
   //
   // Could be slow if a halo with many particles has
-  // 1 <= nr_tracers < NumPartCoreMax (which should be unlikely?).
+  // 1 <= nr_tracers < MaxNumPartMerge.
   //
   if (0 == sub.Nbound)
   {
@@ -73,10 +73,10 @@ void SubHelper_t::BuildPosition(const Subhalo_t &sub)
               sx2[j] += dx * dx * m;
             }
         }
-        if(NumPart==NumPartCoreMax)break;
+        if(NumPart==MaxNumPartMerge)break;
         // Next particle in subhalo
       }
-        if(NumPart==NumPartCoreMax)break;
+        if(NumPart==MaxNumPartMerge)break;
     // Next pass
   }
   
@@ -94,6 +94,8 @@ void SubHelper_t::BuildPosition(const Subhalo_t &sub)
 
 void SubHelper_t::BuildVelocity(const Subhalo_t &sub)
 {
+  // Compute position of a halo using the same particles as for BuildPosition.
+  //
   if (0 == sub.Nbound)
   {
     PhysicalSigmaV = 0.;
@@ -135,10 +137,10 @@ void SubHelper_t::BuildVelocity(const Subhalo_t &sub)
               sx2[j] += dx * dx * m;
             }
         }
-        if(NumPart==NumPartCoreMax)break;
+        if(NumPart==MaxNumPartMerge)break;
         // Next particle in subhalo
       }
-    if(NumPart==NumPartCoreMax)break;
+    if(NumPart==MaxNumPartMerge)break;
     // Next pass
   }
   


### PR DESCRIPTION
For large halos it might be beneficial to consider more than just the 20 most bound particles when determining mergers. This PR introduces a new parameter MaxNumPartMerge. When determining the position and velocity of a subhalo, both satellites and centrals, min(Nbound, MaxNumPartMerge) will now be used instead of 20 every time.

TODO
- [ ] Effect of varying MaxNumPartMerge on output halo catalogues
- [ ] Effect of varying MaxNumPartMerge on HBT runtime