### PR TITLE
Try to make random sampling for unbinding reproducible

### DIFF
--- a/src/config_parser.cpp
+++ b/src/config_parser.cpp
@@ -69,6 +69,7 @@ bool Parameter_t::TrySingleValueParameter(string ParameterName, stringstream &Pa
   TrySetPar(PeriodicBoundaryOn);
   TrySetPar(SnapshotHasIdBlock);
   TrySetPar(MaxPhysicalSofteningHalo);
+  TrySetPar(RandomSeedFactor);
   TrySetPar(TracerParticleBitMask);
 
 #undef TrySetPar
@@ -263,9 +264,9 @@ void Parameter_t::BroadCast(MpiWorker_t &world, int root)
   _SyncAtom(MaxSnapshotIndex, MPI_INT);
   _SyncReal(BoxSize);
   _SyncReal(SofteningHalo);
-  _SyncReal(MaxPhysicalSofteningHalo);
+  _SyncReal(MaxPhysicalSofteningHalo);  
   _SyncVecBool(IsSet);
-
+  _SyncAtom(RandomSeedFactor, MPI_HBT_INT);
   _SyncVec(SnapshotDirBase, MPI_CHAR);
   _SyncVec(SnapshotFormat, MPI_CHAR);
   _SyncVec(GroupFileFormat, MPI_CHAR);
@@ -412,6 +413,7 @@ void Parameter_t::DumpParameters()
   DumpPar(SourceSubRelaxFactor);
   DumpPar(RefineMostboundParticle);
   DumpPar(MaxSampleSizeOfPotentialEstimate);
+  DumpPar(RandomSeedFactor);
 
   DumpHeader("Subhalo Tracking");
   DumpPar(MinNumPartOfSub);

--- a/src/config_parser.h
+++ b/src/config_parser.h
@@ -75,7 +75,8 @@ public:
                                 // leads to more accuracy mostbound particle
 
   int TracerParticleBitMask; /* Bitmask used to identify which particle type can be used as tracer */
-
+  HBTInt RandomSeedFactor; // Modifies the random number seed used for sampling
+  
   /*derived parameters; do not require user input*/
   HBTReal TreeNodeOpenAngleSquare;
   HBTReal TreeNodeResolution;
@@ -119,7 +120,8 @@ public:
     RefineMostboundParticle = true;
     GroupLoadedFullParticle = false;
     MaxPhysicalSofteningHalo = -1; // Indicates no max. physical softening is used.
-
+    RandomSeedFactor = 0; // If zero, just use particle IDs to seed random number generator
+  
     /* Tracer-related parameters. If unset, only use collisionless particles (DM
      * + Stars) as tracer. Here we assume they correspond to particle types 1
      * and 4, respectively. */

--- a/src/subhalo_unbind.cpp
+++ b/src/subhalo_unbind.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <new>
 #include <omp.h>
+#include <random>
 
 #include "datatypes.h"
 #include "gravity_tree.h"
@@ -323,8 +324,13 @@ void Subhalo_t::Unbind(const Snapshot_t &epoch)
   GravityTree_t tree;
   tree.Reserve(Particles.size());
   Nbound = Particles.size(); // start from full set
-  if (MaxSampleSize > 0 && Nbound > MaxSampleSize)
-    random_shuffle(Particles.begin(), Particles.end()); // shuffle for easy resampling later.
+  if (MaxSampleSize > 0 && Nbound > MaxSampleSize) {
+    // Initialize random number generator with first particle ID for reproducibility
+    mt19937 rng;
+    rng.seed(Particles[0].Id);
+    // shuffle for easy resampling later.
+    shuffle(Particles.begin(), Particles.end(), rng);    
+  }
   HBTInt Nlast;
 
   vector<ParticleEnergy_t> Elist(Nbound);

--- a/src/subhalo_unbind.cpp
+++ b/src/subhalo_unbind.cpp
@@ -329,7 +329,7 @@ void Subhalo_t::Unbind(const Snapshot_t &epoch)
     int nr_seed_vals = min(Nbound, (HBTInt) 20);
     vector<HBTInt> ids(nr_seed_vals);
     for(int i=0; i<nr_seed_vals; i+=1)
-      ids[i] = Particles[i].Id;
+      ids[i] = Particles[i].Id ^ HBTConfig.RandomSeedFactor;
     seed_seq seed(ids.begin(), ids.end());
     mt19937 rng(seed);    
     // shuffle for easy resampling later.

--- a/src/subhalo_unbind.cpp
+++ b/src/subhalo_unbind.cpp
@@ -325,9 +325,13 @@ void Subhalo_t::Unbind(const Snapshot_t &epoch)
   tree.Reserve(Particles.size());
   Nbound = Particles.size(); // start from full set
   if (MaxSampleSize > 0 && Nbound > MaxSampleSize) {
-    // Initialize random number generator with first particle ID for reproducibility
-    mt19937 rng;
-    rng.seed(Particles[0].Id);
+    // Initialize random number generator with first few particle IDs for reproducibility
+    int nr_seed_vals = min(Nbound, (HBTInt) 20);
+    vector<HBTInt> ids(nr_seed_vals);
+    for(int i=0; i<nr_seed_vals; i+=1)
+      ids[i] = Particles[i].Id;
+    seed_seq seed(ids.begin(), ids.end());
+    mt19937 rng(seed);    
     // shuffle for easy resampling later.
     shuffle(Particles.begin(), Particles.end(), rng);    
   }


### PR DESCRIPTION
This makes the seed for the random shuffle used in unbinding depend on the particle IDs so that the random number sequence no longer depends on the (unpredictable) order in which threads process halos. It also adds a parameter that can be used to change the seed so that we can run multiple realizations. Particle IDs are xor'd with the supplied parameter and then used to initialize the random number generator. I'm not sure if some other operation would make more sense.

I think this change also fixes two problems with the original code:
  * The random number generator was never seeded so we always got the same, default seed on all MPI ranks
  * Calling std::random_shuffle from multiple threads without specifying the random number generator may have used a non thread-safe default generator

There might still be some non-deterministic behaviour due to rounding error in reduction operations depending on the order of execution.