### PR TITLE
Only write updated Parameters.log on one MPI rank

### DIFF
--- a/HBT.cpp
+++ b/HBT.cpp
@@ -37,7 +37,6 @@ int main(int argc, char **argv)
 
     ParseHBTParams(argc, argv, HBTConfig, snapshot_start, snapshot_end);
     mkdir(HBTConfig.SubhaloPath.c_str(), 0755);
-    HBTConfig.DumpParameters();
 
     cout << argv[0] << " run using " << world.size() << " mpi tasks";
 #ifdef _OPENMP
@@ -78,11 +77,9 @@ int main(int argc, char **argv)
     HaloSnapshot_t halosnap;
     halosnap.Load(world, isnap);
 
-    /* For SWIFT-based outputs, we load parameters directly from the snapshots.
-     * This means that the inital call to DumpParameters (potentially) used
-     * outdated values. This extra call will save the correct ones. */
-    if (HBTConfig.SnapshotFormat == "swiftsim" && (isnap == snapshot_start))
-      HBTConfig.DumpParameters();
+    /* For SWIFT-based outputs we load some parameters directly from the snapshots,
+       so we delay writing Parameters.log until the values are known. */
+    if ((isnap == snapshot_start) && (world.rank() == 0))HBTConfig.DumpParameters();
 
     timer.Tick(world.Communicator);
     halosnap.UpdateParticles(world, partsnap);


### PR DESCRIPTION
This should fix #17. The Parameters.log file is only written by rank zero, which has the correct value for the TracerParticleTypes parameter.

I've also removed the first call to DumpParameters. I don't think there's any harm in just delaying writing the file out at all until we have the parameter values.