### PR TITLE
Multiple tracers for identifying host FOF.

### DIFF
--- a/src/config_parser.cpp
+++ b/src/config_parser.cpp
@@ -48,6 +48,7 @@ bool Parameter_t::TrySingleValueParameter(string ParameterName, stringstream &Pa
   TrySetPar(MinSnapshotIndex);
   TrySetPar(MinNumPartOfSub);
   TrySetPar(MinNumTracerPartOfSub);
+  TrySetPar(NumTracerHostFinding);
   TrySetPar(ParticleIdRankStyle);
   TrySetPar(ParticleIdNeedHash);
   TrySetPar(SnapshotIdUnsigned);
@@ -273,6 +274,7 @@ void Parameter_t::BroadCast(MpiWorker_t &world, int root)
   _SyncAtom(MinSnapshotIndex, MPI_INT);
   _SyncAtom(MinNumPartOfSub, MPI_INT);
   _SyncAtom(MinNumTracerPartOfSub, MPI_INT);
+  _SyncAtom(NumTracerHostFinding, MPI_INT);
   _SyncAtom(GroupParticleIdMask, MPI_LONG);
   _SyncReal(MassInMsunh);
   _SyncReal(LengthInMpch);
@@ -416,6 +418,7 @@ void Parameter_t::DumpParameters()
   DumpHeader("Subhalo Tracking");
   DumpPar(MinNumPartOfSub);
   DumpPar(MinNumTracerPartOfSub);
+  DumpPar(NumTracerHostFinding);
   if (TracerParticleTypes.size())
   {
     version_file << "TracerParticleTypes";

--- a/src/config_parser.h
+++ b/src/config_parser.h
@@ -91,7 +91,7 @@ public:
     MaxConcurrentIO = 10;
     MinSnapshotIndex = 0;
     MinNumPartOfSub = 20;
-    MinNumTracerPartOfSub = 20;
+    MinNumTracerPartOfSub = 10;
     GroupParticleIdMask = 0;
     MassInMsunh = 1e10;
     LengthInMpch = 1;

--- a/src/config_parser.h
+++ b/src/config_parser.h
@@ -42,6 +42,7 @@ public:
   int MinSnapshotIndex;
   int MinNumPartOfSub;
   int MinNumTracerPartOfSub;
+  int NumTracerHostFinding;
   long GroupParticleIdMask; // only used for a peculiar gadget format.
   HBTReal MassInMsunh;
   HBTReal LengthInMpch;
@@ -92,6 +93,7 @@ public:
     MinSnapshotIndex = 0;
     MinNumPartOfSub = 20;
     MinNumTracerPartOfSub = 10;
+    NumTracerHostFinding = MinNumTracerPartOfSub;
     GroupParticleIdMask = 0;
     MassInMsunh = 1e10;
     LengthInMpch = 1;

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -226,11 +226,11 @@ bool GetTracerHosts(vector<HBTInt>::iterator particle_hosts, vector<HBTInt>::con
 
     /* We cannot find the particle in the current rank. We will therefore need to
      * try to find it in other ranks (and hence delay making a host decision) */
-    if ((particle_hosts[BoundRanking] == -1) &&
-        (part_snap.GetIndex(particle_ids[BoundRanking]) == SpecialConst::NullParticleId))
+    if (particle_hosts[BoundRanking] == -1)
     {
-      particle_hosts[BoundRanking]--; // Turns it to -2
-      MakeDecision = false;
+      MakeDecision = false; // Defer making a decision until we have all info.
+      if (part_snap.GetIndex(particle_ids[BoundRanking]) == SpecialConst::NullParticleId)
+        particle_hosts[BoundRanking]--; // Turns it to -2
     }
   }
 

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -506,13 +506,21 @@ void SubhaloSnapshot_t::AssignHosts(MpiWorker_t &world, HaloSnapshot_t &halo_sna
 {
   ParallelizeHaloes = halo_snap.NumPartOfLargestHalo < 0.1 * halo_snap.TotNumberOfParticles; // no dominating objects
 
-  // exchange subhaloes according to hosts
+  /* To hold subhaloes with updated information. */ 
   vector<Subhalo_t> LocalSubhalos;
   LocalSubhalos.reserve(Subhalos.size());
+
+  /* Creates ParticleID - HostHalo information, local to the task. */
   halo_snap.FillParticleHash();
+
+  /* Try identifying which FOF hosts local subhaloes, using local information 
+   * only. */
   FindLocalHosts(halo_snap, part_snap, Subhalos, LocalSubhalos);
+
+  /* Those which require information from external ranks are dealt with here. */
   for (int rank = 0; rank < world.size(); rank++)
     FindOtherHostsSafely(world, rank, halo_snap, part_snap, Subhalos, LocalSubhalos, MPI_HBT_SubhaloShell_t);
+
   Subhalos.swap(LocalSubhalos);
   halo_snap.ClearParticleHash();
 

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -179,11 +179,11 @@ inline HBTInt GetLocalHostId(HBTInt pid, const HaloSnapshot_t &halo_snap, const 
 
 /* Identify and store the particle IDs of the most bound MinNumTracerPartOfSub
  * collisionless tracers. Used to identify host FOF groups. */
-void GetTracerIds(vector<HBTInt> &particle_ids, const Subhalo_t &Subhalo)
+void GetTracerIds(vector<HBTInt>::iterator particle_ids, const Subhalo_t &Subhalo)
 {
   /* Initialise vector. This will make it so the code knows when to stop looking
    * for tracers, since orphans will have all but the first with NullParticleId */
-  fill(particle_ids.begin(), particle_ids.begin() + HBTConfig.MinNumTracerPartOfSub, SpecialConst::NullParticleId);
+  fill(particle_ids, particle_ids + HBTConfig.MinNumTracerPartOfSub, SpecialConst::NullParticleId);
 
   /* Iterate over the particle list to find tracers. */
   int BoundRanking = 0;
@@ -282,7 +282,7 @@ void FindLocalHosts(const HaloSnapshot_t &halo_snap, const ParticleSnapshot_t &p
     {
       /* Create a list of tracer particle IDs*/
       vector<HBTInt> TracerParticleIds(HBTConfig.MinNumTracerPartOfSub);
-      GetTracerIds(TracerParticleIds, Subhalos[subid]);
+      GetTracerIds(TracerParticleIds.begin(), Subhalos[subid]);
 
       /* Identify which FOFs those IDs are located in. */
       vector<HBTInt> TracerHosts(HBTConfig.MinNumTracerPartOfSub);

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -335,7 +335,7 @@ void FindOtherHosts(MpiWorker_t &world, int root, const HaloSnapshot_t &halo_sna
   /* Create vector to hold the IDs of particles to look out for. We assign a 
    * conservative value of MinNumTracerPartOfSub particles per subhalo, even 
    * though we may have orphans in the mix (only require one entry) */
-  vector<vector<HBTInt>> TracerParticleIds(NumSubhalos, vector<HBTInt>(HBTConfig.MinNumTracerPartOfSub));
+  vector<HBTInt> TracerParticleIds(NumSubhalos * HBTConfig.MinNumTracerPartOfSub);
 
   /* Populate the vectors with the ParticleIDs of tracers belonging to the subhaloes
    * of the root task */

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -183,7 +183,7 @@ void GetTracerIds(vector<HBTInt> &particle_ids, const Subhalo_t &Subhalo)
 {
   /* Initialise vector. This will make it so the code knows when to stop looking
    * for tracers, since orphans will have all but the first with NullParticleId */
-  fill(particle_ids.begin(), particle_ids.end(), SpecialConst::NullParticleId);
+  fill(particle_ids.begin(), particle_ids.begin() + HBTConfig.MinNumTracerPartOfSub, SpecialConst::NullParticleId);
 
   /* Iterate over the particle list to find tracers. */
   int BoundRanking = 0;

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -237,20 +237,18 @@ bool GetTracerHosts(vector<HBTInt>::iterator particle_hosts, vector<HBTInt>::con
 HBTInt DecideLocalHostId(const vector<HBTInt> &particle_hosts, const vector<HBTInt> &particle_ids)
 {
   /* To store unique host candidates, and the matching score. */
-  std::unordered_map<HBTInt, float> CandidateHosts;
+  unordered_map<HBTInt, float> CandidateHosts;
 
-  /* To weight host candidate score by how bound was the particle was */
-  float BoundRanking = 0.;
-
-  /* Iterate over the particle list. */
-  for(int i = 0; i < HBTConfig.MinNumTracerPartOfSub; i++)
+  /* Iterate over the particle list, and weight each candidate score by how 
+   * bound was the particle is */
+  for(int BoundRanking = 0; BoundRanking < HBTConfig.MinNumTracerPartOfSub; BoundRanking++)
   {
-    // No more tracers left (should only occur for orphans!)
-    if(particle_ids[i] == SpecialConst::NullParticleId)
-      break;
+    // Not a valid tracer (NOTE: should we break or continue here?)
+    if(particle_hosts[BoundRanking] == -2)
+      continue;
 
     /* If the key is not present, the score gets zero-initialised by default */
-    CandidateHosts[particle_hosts[i]] += 1.0 / (1 + pow(BoundRanking++, 0.5));
+    CandidateHosts[particle_hosts[BoundRanking]] += 1.0 / (1 + pow(float(BoundRanking), 0.5));
   }
 
   /* Select candidate host with the highest score. */
@@ -288,7 +286,7 @@ void FindLocalHosts(const HaloSnapshot_t &halo_snap, const ParticleSnapshot_t &p
       /* If we found all tracers in the current rank, make a host decision. 
        * Otherwise, we will need to use information from other ranks to be sure 
        * of where the track is. */
-      Subhalos[subid].HostHaloId = (MakeDecision) ? DecideLocalHostId(TracerHosts, TracerParticleIds) : -2;
+      Subhalos[subid].HostHaloId = (MakeDecision) ? DecideLocalHostId(TracerHosts.cbegin()) : -2;
     }
     else
       Subhalos[subid].HostHaloId = -1;

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -234,7 +234,7 @@ bool GetTracerHosts(vector<HBTInt>::iterator particle_hosts, vector<HBTInt>::con
  * MinNumTracerPartOfSub most bound collisionless particles. This decision is
  * weighted by the binding energy ranking the particles had in the previous
  * output. */
-HBTInt DecideLocalHostId(const vector<HBTInt> &particle_hosts, const vector<HBTInt> &particle_ids)
+HBTInt DecideLocalHostId(vector<HBTInt>::const_iterator particle_hosts)
 {
   /* To store unique host candidates, and the matching score. */
   unordered_map<HBTInt, float> CandidateHosts;

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -338,18 +338,10 @@ void FindOtherHosts(MpiWorker_t &world, int root, const HaloSnapshot_t &halo_sna
   {
 #pragma omp parallel for if (NumSubhalos > 20)
     for (HBTInt i = 0; i < NumSubhalos; i++)
-      GetTracerIds(TracerParticleIds[i], Subhalos[i]);
+      GetTracerIds(TracerParticleIds.begin() + i * HBTConfig.MinNumTracerPartOfSub, Subhalos[i]);
   }
 
-  /* Convert 2D vector into 1D C array, for communication purposes */
-  vector<HBTInt> TracerParticleIds_ToCommunicate(NumSubhalos * HBTConfig.MinNumTracerPartOfSub);
-  if (thisrank == root)
-  {
-    int elements  = 0;
-    for (auto entry : TracerParticleIds)
-      copy(entry.begin(), entry.end(), TracerParticleIds_ToCommunicate.begin() + HBTConfig.MinNumTracerPartOfSub * elements++);
-  }
-  MPI_Bcast(TracerParticleIds_ToCommunicate.data(), TracerParticleIds_ToCommunicate.size(), MPI_HBT_INT, root, world.Communicator);
+  MPI_Bcast(TracerParticleIds.data(), TracerParticleIds.size(), MPI_HBT_INT, root, world.Communicator);
 
   TrackParticleIds.resize(NumSubhalos);
   if (thisrank == root)

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -195,6 +195,11 @@ void GetTracerIds(vector<HBTInt>::iterator particle_ids, const Subhalo_t &Subhal
     if (BoundRanking == HBTConfig.MinNumTracerPartOfSub) // Use up to a user-defined number of tracers.
       break;
   }
+
+  /* Sanity checks */
+  assert(Subhalo.Particles.size() != 0); // Do not call the function for empty subhaloes.
+  assert(BoundRanking == min(Subhalo.Particles.size(),
+                             HBTConfig.MinNumTracerPartOfSub)); // We found all expected particles
 }
 
 /* Identify which FOF is host to the particles. If we have a value of -2, that

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -380,7 +380,7 @@ void FindOtherHosts(MpiWorker_t &world, int root, const HaloSnapshot_t &halo_sna
   if (thisrank == root)
   {
     NumSubhalos = Subhalos.size();
-    if (NumSubhalos > INT_MAX)
+    if (NumSubhalos * HBTConfig.NumTracerHostFinding > INT_MAX)
       throw runtime_error("Error: in FindOtherHosts(), sending more subhaloes than INT_MAX will cause MPI message to "
                           "overflow. Please try more MPI threads. aborting.\n");
   }

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -307,6 +307,16 @@ void FindOtherHosts(MpiWorker_t &world, int root, const HaloSnapshot_t &halo_sna
       GetTracerIds(TracerParticleIds[i], Subhalos[i]);
   }
 
+  /* Convert 2D vector into 1D C array, for communication purposes */
+  vector<HBTInt> TracerParticleIds_ToCommunicate(NumSubhalos * HBTConfig.MinNumTracerPartOfSub);
+  if (thisrank == root)
+  {
+    int elements  = 0;
+    for (auto entry : TracerParticleIds)
+      copy(entry.begin(), entry.end(), TracerParticleIds_ToCommunicate.begin() + HBTConfig.MinNumTracerPartOfSub * elements++);
+  }
+  MPI_Bcast(TracerParticleIds_ToCommunicate.data(), TracerParticleIds_ToCommunicate.size(), MPI_HBT_INT, root, world.Communicator);
+
   TrackParticleIds.resize(NumSubhalos);
   if (thisrank == root)
   {

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -197,11 +197,47 @@ void GetTracerIds(vector<HBTInt> &particle_ids, const Subhalo_t &Subhalo)
   }
 }
 
+/* Identify which FOF is host to the particles. If we have a value of -2, that
+ * means the particle was not found in the particle information available to the 
+ * local rank. */
+bool GetTracerHosts(vector<HBTInt> &particle_hosts, const vector<HBTInt> &particle_ids, const HaloSnapshot_t &halo_snap, const ParticleSnapshot_t &part_snap)
+{
+  /* Initialise vector. This will make it so the code knows when to stop looking
+   * for tracers, since orphans will have all but the first with NullParticleId */
+  fill(particle_hosts.begin(), particle_hosts.begin() + HBTConfig.MinNumTracerPartOfSub, -2);
+
+  bool MakeDecision = true;
+
+  /* Iterate over the particle list to find hosts. */
+  int BoundRanking = 0;
+  for (auto id : particle_ids)
+  {
+    // No more tracers left (should only occur for orphans!)
+    if(id == SpecialConst::NullParticleId)
+      break;
+
+    // Get host, which can be -1
+    particle_hosts[BoundRanking] = halo_snap.ParticleHash.GetIndex(id);
+
+    /* We cannot find the particle in the current rank. We will therefore need to 
+     * try to find it in other ranks (and hence delay making a host decision) */
+    if(particle_hosts[BoundRanking] == -1 && part_snap.GetIndex(id) == -1)
+    {
+      particle_hosts[BoundRanking]--; // Turns it to -2
+      MakeDecision = false;
+    }
+
+    BoundRanking++;
+  }
+
+  return MakeDecision;
+}
+
 /* Assign a host to a given subgroup based on the FoF membership of the
  * MinNumTracerPartOfSub most bound collisionless particles. This decision is
  * weighted by the binding energy ranking the particles had in the previous
  * output. */
-HBTInt DecideLocalHostId(const vector<HBTInt> &particle_ids, const HaloSnapshot_t &halo_snap, const ParticleSnapshot_t &part_snap)
+HBTInt DecideLocalHostId(const vector<HBTInt> &particle_hosts, const vector<HBTInt> &particle_ids)
 {
   /* To store unique host candidates, and the matching score. */
   std::unordered_map<HBTInt, float> CandidateHosts;
@@ -210,17 +246,14 @@ HBTInt DecideLocalHostId(const vector<HBTInt> &particle_ids, const HaloSnapshot_
   float BoundRanking = 0.;
 
   /* Iterate over the particle list. */
-  for (auto id : particle_ids)
+  for(int i = 0; i < HBTConfig.MinNumTracerPartOfSub; i++)
   {
     // No more tracers left (should only occur for orphans!)
-    if(id == SpecialConst::NullParticleId)
+    if(particle_ids[i] == SpecialConst::NullParticleId)
       break;
 
-    // Get host, which can be -1
-    HBTInt Host = halo_snap.ParticleHash.GetIndex(id);
-
     /* If the key is not present, the score gets zero-initialised by default */
-    CandidateHosts[Host] += 1.0 / (1 + pow(BoundRanking++, 0.5));
+    CandidateHosts[particle_hosts[i]] += 1.0 / (1 + pow(BoundRanking++, 0.5));
   }
 
   /* Select candidate host with the highest score. */
@@ -251,8 +284,14 @@ void FindLocalHosts(const HaloSnapshot_t &halo_snap, const ParticleSnapshot_t &p
       vector<HBTInt> TracerParticleIds(HBTConfig.MinNumTracerPartOfSub);
       GetTracerIds(TracerParticleIds, Subhalos[subid]);
 
-      /* Use several particles to score different FOFs */
-      Subhalos[subid].HostHaloId = DecideLocalHostId(TracerParticleIds, halo_snap, part_snap);
+      /* Identify which FOFs those IDs are located in. */
+      vector<HBTInt> TracerHosts(HBTConfig.MinNumTracerPartOfSub);
+      bool MakeDecision = GetTracerHosts(TracerHosts, TracerParticleIds, halo_snap, part_snap);
+
+      /* If we found all tracers in the current rank, make a host decision. 
+       * Otherwise, we will need to use information from other ranks to be sure 
+       * of where the track is. */
+      Subhalos[subid].HostHaloId = (MakeDecision) ? DecideLocalHostId(TracerHosts, TracerParticleIds) : -2;
     }
     else
       Subhalos[subid].HostHaloId = -1;

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -183,7 +183,7 @@ void GetTracerIds(vector<HBTInt> &particle_ids, const Subhalo_t &Subhalo)
 {
   /* Initialise vector. This will make it so the code knows when to stop looking
    * for tracers, since orphans will have all but the first with NullParticleId */
-  particle_ids.assign(HBTConfig.MinNumTracerPartOfSub, SpecialConst::NullParticleId);
+  fill(particle_ids.begin(), particle_ids.end(), SpecialConst::NullParticleId);
 
   /* Iterate over the particle list to find tracers. */
   int BoundRanking = 0;
@@ -248,7 +248,7 @@ void FindLocalHosts(const HaloSnapshot_t &halo_snap, const ParticleSnapshot_t &p
     if (Subhalos[subid].Particles.size())
     {
       /* Create a list of tracer particle IDs*/
-      vector<HBTInt> TracerParticleIds;
+      vector<HBTInt> TracerParticleIds(HBTConfig.MinNumTracerPartOfSub);
       GetTracerIds(TracerParticleIds, Subhalos[subid]);
 
       /* Use several particles to score different FOFs */

--- a/testing/duplicate_track_identification.py
+++ b/testing/duplicate_track_identification.py
@@ -1,0 +1,194 @@
+import h5py
+import numpy as np
+from tqdm import tqdm
+from repository.analysis import tools
+
+def quick_search(input_array, search_values, sorter_array=None):
+    '''
+    Performs a search for the location of one or more values in an array.  
+
+    Parameters
+    -----------
+    input_array : np.ndarray
+        Array to search through. It should be sorted in ascending value order. If not,
+        a sorter_array is needed.
+    search_value : np.ndarray
+        One or more values to search for in the input_array.
+    sorter_array : np.ndarray, opt
+        Array of integers used to sort input_array in ascending value order,
+        i.e. sorter_array = np.argsort(input_array)
+
+    Returns
+    -----------
+
+    np.ndarray
+        Array with integers corresponding to the positional index of where the values of
+        interest are located in the input_array. Note that if a subset of values are 
+        missing, no warning is thrown.
+    '''
+
+    left  = np.searchsorted(input_array,search_values,side='left' , sorter = sorter_array)
+    right = np.searchsorted(input_array,search_values,side='right', sorter = sorter_array)
+
+    unique_elements = left[left!= right]
+
+    if (len(unique_elements) != 0):
+        if sorter_array is not None:
+            return sorter_array[unique_elements]
+        else:
+            return unique_elements
+
+def load_catalogue_memberships(catalogue_path):
+    '''
+    Retrieves the information of which particles were bound to the subhaloes 
+    whose host FOF we want to identify.
+
+    Parameters
+    -----------
+    catalogue_path : str
+        Location of the (ordered) HBT catalogue file
+
+    Returns
+    -----------
+    ids
+        IDs of the particles that are bound to the subgroups present in the 
+        catalogue.
+    offsets
+        Location of the first bound particle of a given subgroup.
+    lengths
+        The number of particles bound to a given subgroup.
+    '''
+
+    with h5py.File(catalogue_path) as hbt_catalogue:
+        offsets = hbt_catalogue['Subhalos/ParticleOffset'][()]
+        lengths = hbt_catalogue['Subhalos/Nbound'][()]
+        ids     = hbt_catalogue['Particles/ParticleIDs'][()]
+
+    return ids, offsets, lengths
+
+def save_mass_function(lengths, duplicate_tracks, fraction_shared_particles, output_index):
+    import matplotlib.pyplot as plt
+    plt.style.use('/cosma/home/durham/dc-foro1/scripts/matplotlib_config/MNRAS_style.mplstyle')
+    
+    fig, ax1 = plt.subplots(1)
+
+    # All currents subgroups
+    ax1.plot(np.sort(lengths)[::-1], np.arange(len(lengths)) + 1,'k',label='All')
+    
+    # Duplicate tracks
+    if(len(duplicate_tracks) > 0 ):
+        ax1.plot(np.sort(lengths[duplicate_tracks])[::-1], np.arange(len(duplicate_tracks)) + 1,'b',label='Subgroups with duplicate particles')
+        
+        ax1.plot(np.sort(lengths[duplicate_tracks[fraction_shared_particles > 0.5]])[::-1], np.arange(len(duplicate_tracks[fraction_shared_particles > 0.5])) + 1,'r',label='Subgroups with >50% duplicate particles')
+    
+    # Only show resolved objects.
+    ax1.set_xlim(left=20)
+    
+    # Scale
+    ax1.set_xscale('log')
+    ax1.set_yscale('log')
+
+    # Labels
+    ax1.set_xlabel(r'$N_{\mathrm{bound}}$')
+    ax1.set_ylabel(r'$N(> N_{\mathrm{bound}})$')
+
+    #Legend
+    ax1.legend()
+
+    plt.savefig(f'duplicate_mass_function_snapindex_{output_index:03d}')
+    plt.close()
+    
+
+
+def get_duplicate_tracks(catalogue_path, output_index, plot = False):
+    '''
+    Identifies all subgroups which share particles with others. It also makes a 
+    bound mass function classified according to different, if enabled
+
+    Parameters
+    -----------
+    catalogue_path : f-str
+        Location of the ordered HBT catalogue files.
+    output_index : int
+        The catalogue output number to analyse. May not correspond to snapshot
+        number, if a subset of them has been analysed.
+    plot : opt, bool
+        Generate a bound mass function and save.
+
+    Returns 
+    -----------
+    duplicate_tracks : np.ndarray
+        The TrackId of objects which share
+    duplicate_fraction : np.ndarray
+        The fraction of particles bound to a given object that are found in 
+        other ones. 
+    '''
+
+    # Get current snapshot
+    with h5py.File(catalogue_path.format(output_index)) as hbt_catalogue:
+        snapshot_number = hbt_catalogue['SnapshotId'][0]
+
+    print(f"Determining host haloes of subgroups in snapshot {snapshot_number} (Output Index = {output_index + 1})")
+
+    # Get particle information
+    hbt_ids, hbt_offsets, hbt_lengths = load_catalogue_memberships(catalogue_path.format(output_index))
+    id_sorter = np.argsort(hbt_ids)
+
+    # Get the particle membership in the previous output
+    number_subhaloes = len(hbt_lengths)
+
+    # To store information
+    duplicate_tracks = []
+    fraction_shared_particles = []
+
+    # Iterate over all existing subgroups, identify if other subgroups host 
+    # its particles, and if so, identify as duplicate. 
+    for trackid in tqdm(range(number_subhaloes)):
+
+        # Skip orphans
+        if(hbt_lengths[trackid] <= 1):
+            continue
+        
+        # Get all bound particles
+        subgroup_particle_ids = hbt_ids[hbt_offsets[trackid] : hbt_offsets[trackid] + hbt_lengths[trackid]]
+        
+        # Find where they are located
+        idx = tools.quick_search(hbt_ids, subgroup_particle_ids, id_sorter)
+        
+        # Classify into tracks
+        found_trackids = np.digitize(idx, hbt_offsets) - 1
+        
+        # Remove orphan tracks
+        idx = idx[hbt_lengths[found_trackids] > 1]
+        found_trackids = found_trackids[hbt_lengths[found_trackids] > 1]
+
+        # Get the UNIQUE ids that are duplicate
+        idx = idx[found_trackids != trackid]
+        duplicate_ids = np.unique(hbt_ids[idx])
+        
+        # Store information of those which are duplicate
+        if(len(duplicate_ids) != 0):
+            duplicate_tracks.append(trackid)
+            fraction_shared_particles.append(len(duplicate_ids) / hbt_lengths[trackid])
+    
+    duplicate_tracks = np.array(duplicate_tracks)
+    fraction_shared_particles = np.array(fraction_shared_particles)
+
+    if plot:
+        save_mass_function(hbt_lengths, duplicate_tracks, fraction_shared_particles, output_index)
+
+    return np.array(duplicate_tracks), np.array(fraction_shared_particles)
+
+if __name__ == "__main__":
+
+    # Where the particle data is located
+    snapshot_paths = '/cosma7/data/dp004/dc-foro1/colibre/colibre_{:04d}.hdf5'
+
+    # The location of ordered particle data (see /toolbox/sort_hbt_output.py) 
+    sorted_catalogue_path = '/cosma7/data/dp004/dc-foro1/colibre/hbt_testing/omp_tracing/ordered_output/OrderedSubSnap_{:03d}.hdf5'
+
+    # Make a plot? 
+    make_plot = True
+
+    for output_index in range(15):
+        tracks, number_fraction = get_duplicate_tracks(sorted_catalogue_path, output_index, make_plot)

--- a/testing/duplicate_track_identification.py
+++ b/testing/duplicate_track_identification.py
@@ -1,7 +1,6 @@
 import h5py
 import numpy as np
 from tqdm import tqdm
-from repository.analysis import tools
 
 def quick_search(input_array, search_values, sorter_array=None):
     '''
@@ -153,7 +152,7 @@ def get_duplicate_tracks(catalogue_path, output_index, plot = False):
         subgroup_particle_ids = hbt_ids[hbt_offsets[trackid] : hbt_offsets[trackid] + hbt_lengths[trackid]]
         
         # Find where they are located
-        idx = tools.quick_search(hbt_ids, subgroup_particle_ids, id_sorter)
+        idx = quick_search(hbt_ids, subgroup_particle_ids, id_sorter)
         
         # Classify into tracks
         found_trackids = np.digitize(idx, hbt_offsets) - 1

--- a/testing/host_halo_identification.py
+++ b/testing/host_halo_identification.py
@@ -1,0 +1,200 @@
+import h5py
+import numpy as np
+import swiftsimio as sw
+from repository.analysis import tools
+
+def quick_search(input_array, search_values, sorter_array=None):
+    '''
+    Performs a search for the location of one or more values in an array.  
+
+    Parameters
+    -----------
+    input_array : np.ndarray
+        Array to search through. It should be sorted in ascending value order. If not,
+        a sorter_array is needed.
+    search_value : np.ndarray
+        One or more values to search for in the input_array.
+    sorter_array : np.ndarray, opt
+        Array of integers used to sort input_array in ascending value order,
+        i.e. sorter_array = np.argsort(input_array)
+
+    Returns
+    -----------
+
+    np.ndarray
+        Array with integers corresponding to the positional index of where the values of
+        interest are located in the input_array. Note that if a subset of values are 
+        missing, no warning is thrown.
+    '''
+
+    left  = np.searchsorted(input_array,search_values,side='left' , sorter = sorter_array)
+    right = np.searchsorted(input_array,search_values,side='right', sorter = sorter_array)
+
+    unique_elements = left[left!= right]
+
+    if (len(unique_elements) != 0):
+        if sorter_array is not None:
+            return sorter_array[unique_elements]
+        else:
+            return unique_elements
+
+def rank_weight(rank):
+    '''
+    Function used to weigh the contribution of each particle towards a host FOF
+    decision, based on its boundness ranking.
+
+    Parameters
+    -----------
+    rank : np.ndarray
+        Boundness ranking of the particle, in the previous output..
+
+    Returns
+    -----------
+    np.ndarray
+        The weight of the particle used to score candidates.
+    '''
+    return 1 / (1 + np.sqrt(rank))
+
+def score_function(fof_groups):
+    '''
+    Score each candidate FOF based on several particles. Return the host with the
+    highest score.
+
+    Parameters
+    -----------
+    fof_groups : np.ndarray
+        The FOF group membership of a series of particles, previously sorted
+        descending boundness ranking order.
+
+    Returns
+    -----------
+    int
+        The highest scoring FOF candidate.
+    '''
+    weights = rank_weight(np.arange(len(fof_groups)))
+    
+    unique_candidates = np.unique(fof_groups)
+    scores = {}
+    for cand in unique_candidates:
+        scores[cand] = np.sum(weights[fof_groups == cand])
+
+    temp = max(scores.values())
+    result = [key for key in scores if scores[key] == temp][0] 
+
+    return result
+
+def load_particle_information(snapshot_path):
+    '''
+    Retrieves the information of collisionless tracers (DM + stars) that is 
+    required to determine where subhaloes end up in.
+    '''
+
+    data = sw.load(snapshot_path)
+
+    dm_ids = data.dark_matter.particle_ids.value
+    dm_fof = data.dark_matter.fofgroup_ids.value
+    
+    try: 
+        star_ids = data.stars.particle_ids.value
+        star_fof = data.stars.fofgroup_ids.value
+    except:
+        star_ids = np.ones(1) * -1
+        star_fof = np.ones(1) * -1
+
+    particle_ids = np.hstack([dm_ids, star_ids]).astype(int)
+    particle_fof = np.hstack([dm_fof, star_fof]).astype(int)
+    particle_types =  np.hstack([np.ones(dm_fof.shape), np.ones(star_fof.shape) * 4]).astype(int)
+    particle_fof[particle_fof == 2147483647] = -1
+
+    return particle_ids, particle_types, particle_fof
+
+def load_catalogue_memberships(catalogue_path):
+    '''
+    Retrieves the information of which particles were bound to the subhaloes 
+    whose host FOF we want to identify.
+
+    Parameters
+    -----------
+    catalogue_path : str
+        Location of the (ordered) HBT catalogue file
+
+    Returns
+    -----------
+    ids
+        IDs of the particles that are bound to the subgroups present in the 
+        catalogue.
+    offsets
+        Location of the first bound particle of a given subgroup.
+    lengths
+        The number of particles bound to a given subgroup.
+    '''
+
+    with h5py.File(catalogue_path) as hbt_catalogue:
+        offsets = hbt_catalogue['Subhalos/ParticleOffset'][()]
+        lengths = hbt_catalogue['Subhalos/Nbound'][()]
+        ids     = hbt_catalogue['Particles/ParticleIDs'][()]
+
+    return ids, offsets, lengths
+
+def determine_descendants(catalogue_path, snapshot_paths, output_index):
+    '''
+    Checks whether the host FOF choice made internally by HBT agrees with the 
+    result we find in postprocessing.
+
+    Parameters
+    -----------
+    catalogue_path : f-str
+        Location of the ordered HBT catalogue files.
+    snapshot_paths : f-str
+        Location of the snapshot files containing particle information.
+    output_index : int
+        The catalogue output number to analyse. May not correspond to snapshot
+        number, if a subset of them has been analysed.
+    '''
+
+    # Get the catalogue following the current output.
+    with h5py.File(catalogue_path.format(output_index + 1)) as hbt_catalogue:
+        snapshot_number = hbt_catalogue['SnapshotId'][0]
+        hosts = hbt_catalogue['Subhalos/HostHaloId'][()]
+    
+    print(f"Determining host haloes of subgroups in snapshot {snapshot_number} (Output Index = {output_index + 1})")
+    
+    # Load particle information
+    particle_ids, particle_types, particle_fof = load_particle_information(snapshot_paths.format(snapshot_number))
+    id_sorter = np.argsort(particle_ids)
+
+    # Get the particle membership in the previous output
+    hbt_ids, hbt_offsets, hbt_lengths = load_catalogue_memberships(catalogue_path.format(output_index))
+    number_subhaloes = len(hbt_lengths)
+
+    # Iterate over all previously existing subgroups, identify a host fof and 
+    # check if it agrees with the internal decision made by HBT.
+    for trackid in range(number_subhaloes):
+
+        # Get all particle types.
+        subgroup_particle_ids = hbt_ids[hbt_offsets[trackid] : hbt_offsets[trackid] + hbt_lengths[trackid]]
+        
+        # Try to find in the DM + star array, which will automatically return 
+        # collisionless types. We search for all particle types initially since 
+        # gas in the previous snapshot may be stars in the current one.
+        tracer_idx = quick_search(particle_ids,subgroup_particle_ids,id_sorter)[:10]
+
+        # Score candidates and choose the one with the highest score.
+        decided_fof = score_function(particle_fof[tracer_idx])
+
+        # Check agaist what we had, and see whether we agree.
+        if(decided_fof != hosts[trackid]):
+            print (f"Error in Host identification: Snap {snapshot_number} and TrackId {trackid}. Post-processing value is {decided_fof} but the catalogue has {hosts[trackid]}. Nbound = {hbt_lengths[trackid]}")
+            for idx in tracer_idx:
+                print(f"ParticleID = {particle_ids[idx]} ParticleType = {particle_types[idx]} Host FOF = {particle_fof[idx]}")            
+
+if __name__ == "__main__":
+
+    # Where the particle data is located
+    snapshot_paths = '/cosma7/data/dp004/dc-foro1/colibre/colibre_{:04d}.hdf5'
+
+    # The location of ordered particle data (see /toolbox/sort_hbt_output.py) 
+    sorted_catalogue_path = '/cosma7/data/dp004/dc-foro1/colibre/hbt_testing/omp_tracing/ordered_output/OrderedSubSnap_{:03d}.hdf5'
+
+    for output_index in range(15):
+        determine_descendants(sorted_catalogue_path, snapshot_paths, output_index)

--- a/testing/host_halo_identification.py
+++ b/testing/host_halo_identification.py
@@ -1,7 +1,6 @@
 import h5py
 import numpy as np
 import swiftsimio as sw
-from repository.analysis import tools
 
 def quick_search(input_array, search_values, sorter_array=None):
     '''


### PR DESCRIPTION
New method of tracing where subhaloes end up, which uses more than one tracer particle. Intended to solve issues relating to duplicate/masked-out subhaloes, as they are largely caused by (individual) most bound particles becoming hostless. 

The merit function is based on GADGET-4, whereby we score each candidate FOF by doing a weighted sum of the most bound particle's FoF hosts. This can still result in hostless haloes, if most of the subhalo core ends up away from a FOF.