### PR TITLE
Keep tracer during masking

### DIFF
--- a/format.sh
+++ b/format.sh
@@ -14,7 +14,7 @@ then
   echo "Formatting environment not found, installing it..."
   python3 -m venv clang_formatting_env
   ./clang_formatting_env/bin/python3 -m pip install --upgrade pip # Need to access wheel  
-  ./clang_formatting_env/bin/python3 -m pip install clang-format
+  ./clang_formatting_env/bin/python3 -m pip install clang-format==17.0.6
 fi
 
 # Activate enviroment to enable clang-format command

--- a/src/subhalo.h
+++ b/src/subhalo.h
@@ -119,6 +119,7 @@ public:
     SnapshotIndexOfSink = SpecialConst::NullSnapshotId;
     SinkTrackId = SpecialConst::NullTrackId;
     MostBoundParticleId = SpecialConst::NullParticleId;
+    TracerIndex = -1;
   }
   void Unbind(const Snapshot_t &epoch);
   void RecursiveUnbind(SubhaloList_t &Subhalos, const Snapshot_t &snap);

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -886,25 +886,16 @@ public:
     // If all tracers are removed during masking, we need to add one back
     bool hasTracer = false;
     // Save the most bound tracer from the previous snapshot so we can add it back
-    // For centrals the first particle is guaranteed to be the most bound tracer
-    // For satellites this is not the case, so we use the first tracer we find
-    auto tracer = subhalo.Particles[0];
+    auto tracer = subhalo.Particles[subhalo.GetTracerIndex()];
     auto it_begin = subhalo.Particles.begin(), it_save = it_begin;
     for (auto it = it_begin; it != subhalo.Particles.end(); ++it)
     {
-      if (!tracer.IsTracer() && it->IsTracer())
-      {
-        tracer = *it;
-      }
       auto insert_status = ExclusionList.insert(it->Id);
       if (insert_status.second) // inserted, meaning not excluded
       {
-        if (!hasTracer)
+        if (!hasTracer && it->IsTracer())
         {
-          if (it->IsTracer())
-          {
-            hasTracer = true;
-          }
+          hasTracer = true;
         }
         if (it != it_save)
           *it_save = move(*it);

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -529,11 +529,13 @@ void SubhaloSnapshot_t::FeedCentrals(HaloSnapshot_t &halo_snap)
       central.Particles.swap(Host.Particles); // reuse the halo particles
       central.Nbound = central.Particles.size();
       {
-        auto mostbndid = Host.Particles[0].Id;
+        // TracerIndex exists for the subhalo instance, not the host one.
+        auto mostbndid = Host.Particles[central.GetTracerIndex()].Id;
         for (auto &p : central.Particles)
-          if (p.Id == mostbndid) // swap previous mostbound particle to the beginning
+          if (p.Id == mostbndid) // Swap previous tracer particle to the start (if contained within the FOF)
           {
             swap(p, central.Particles[0]);
+            central.SetTracerIndex(0);
             break;
           }
       }

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -527,7 +527,7 @@ void SubhaloSnapshot_t::FeedCentrals(HaloSnapshot_t &halo_snap)
       auto &central = Subhalos[Members[0]];
       assert(central.Particles.size());
       HBTInt tracerIndex = central.GetTracerIndex(); // Save tracerIndex before swap
-      central.Particles.swap(Host.Particles); // reuse the halo particles
+      central.Particles.swap(Host.Particles);        // reuse the halo particles
       central.Nbound = central.Particles.size();
       bool tracerIndexSet = false;
       // Use the most bound tracer from the previous snapshot that remains
@@ -911,13 +911,10 @@ public:
     if (!hasTracer)
     {
       *it_save = tracer;
-      // TODO: Update tracerindex? Don't think I should need to
-      // subhalo.SetTracerIndex(it_save - it_begin)
       ++it_save;
     }
     subhalo.Particles.resize(it_save - it_begin);
   }
-  // TODO: Remove introduced TODO comments and run formatter
 };
 
 void SubhaloSnapshot_t::MaskSubhalos()

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -881,14 +881,11 @@ public:
     if (subhalo.Nbound <= 1)
       return; // skip orphans
 
+    // The following procedure is only relevant for pre-existing subhalos, as
+    // newly created centrals cannot have any satellites by definition.
+    bool hasTracer = false;
     // Save first tracer so we can add it back if all tracers are masked out
     auto tracer = subhalo.Particles[0];
-    if (!tracer.IsTracer())
-    {
-      throw runtime_error("No tracer particle found before masking");
-    }
-
-    bool hasTracer = false;
     auto it_begin = subhalo.Particles.begin(), it_save = it_begin;
     for (auto it = it_begin; it != subhalo.Particles.end(); ++it)
     {

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -536,8 +536,8 @@ void SubhaloSnapshot_t::FeedCentrals(HaloSnapshot_t &halo_snap)
       {
         if (tracerIndexSet)
           break;
-        while (!Host.Particles[i].IsTracer())
-          i++;
+        if (!Host.Particles[i].IsTracer())
+          continue;
         auto mostbndid = Host.Particles[i].Id;
         for (auto &p : central.Particles)
         {

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -526,13 +526,12 @@ void SubhaloSnapshot_t::FeedCentrals(HaloSnapshot_t &halo_snap)
     {
       auto &central = Subhalos[Members[0]];
       assert(central.Particles.size());
-      HBTInt tracerIndex = central.GetTracerIndex(); // Save tracerIndex before swap
       central.Particles.swap(Host.Particles);        // reuse the halo particles
       central.Nbound = central.Particles.size();
       bool tracerIndexSet = false;
       // Use the most bound tracer from the previous snapshot that remains
       // in the FOF group as the tracer. We need this information for the masking.
-      for (HBTInt i = tracerIndex; i < Host.Particles.size(); i++)
+      for (HBTInt i = 0; i < Host.Particles.size(); i++)
       {
         if (tracerIndexSet)
           break;

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -864,16 +864,31 @@ public:
     if (subhalo.Nbound <= 1)
       return; // skip orphans
 
+    // TODO: Run formatter
+    // TODO: Does this break if MinNumTracer == 0?
+    auto tracer = subhalo.Particles[subhalo.GetTracerIndex()];
+    bool hasTracer = false;
     auto it_begin = subhalo.Particles.begin(), it_save = it_begin;
     for (auto it = it_begin; it != subhalo.Particles.end(); ++it)
     {
       auto insert_status = ExclusionList.insert(it->Id);
       if (insert_status.second) // inserted, meaning not excluded
       {
+        if (!hasTracer) {
+            if (it->IsTracer()) {
+                hasTracer = true;
+            }
+        }
         if (it != it_save)
           *it_save = move(*it);
         ++it_save;
       }
+    }
+    // If all tracers have been removed during masking, add back the most bound
+    if (!hasTracer) {
+        cout << "Tracer removed during masking\n";
+        *it_save = tracer;
+        ++it_save;
     }
     subhalo.Particles.resize(it_save - it_begin);
   }

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -526,12 +526,13 @@ void SubhaloSnapshot_t::FeedCentrals(HaloSnapshot_t &halo_snap)
     {
       auto &central = Subhalos[Members[0]];
       assert(central.Particles.size());
+      HBTInt tracerIndex = central.GetTracerIndex(); // Save tracerIndex before swap
       central.Particles.swap(Host.Particles); // reuse the halo particles
       central.Nbound = central.Particles.size();
       bool tracerIndexSet = false;
       // Use the most bound tracer from the previous snapshot that remains
       // in the FOF group as the tracer. We need this information for the masking.
-      for (HBTInt i = central.GetTracerIndex(); i < Host.Particles.size(); i++)
+      for (HBTInt i = tracerIndex; i < Host.Particles.size(); i++)
       {
         if (tracerIndexSet)
           break;

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -871,11 +871,11 @@ public:
     auto tracer = subhalo.Particles[0];
     for (auto it = subhalo.Particles.begin(); it != subhalo.Particles.end(); ++it)
     {
-        if (it->IsTracer())
-        {
-          tracer = *it;
-          break;
-        }
+      if (it->IsTracer())
+      {
+        tracer = *it;
+        break;
+      }
     }
     if (!tracer.IsTracer())
     {
@@ -889,10 +889,12 @@ public:
       auto insert_status = ExclusionList.insert(it->Id);
       if (insert_status.second) // inserted, meaning not excluded
       {
-        if (!hasTracer) {
-            if (it->IsTracer()) {
-                hasTracer = true;
-            }
+        if (!hasTracer)
+        {
+          if (it->IsTracer())
+          {
+            hasTracer = true;
+          }
         }
         if (it != it_save)
           *it_save = move(*it);
@@ -900,15 +902,16 @@ public:
       }
     }
     // If all tracers have been removed during masking, add back the most bound
-    if (!hasTracer) {
-        *it_save = tracer;
-        // TODO: Update tracerindex? Don't think I should need to
-        // subhalo.SetTracerIndex(it_save - it_begin)
-        ++it_save;
+    if (!hasTracer)
+    {
+      *it_save = tracer;
+      // TODO: Update tracerindex? Don't think I should need to
+      // subhalo.SetTracerIndex(it_save - it_begin)
+      ++it_save;
     }
     subhalo.Particles.resize(it_save - it_begin);
   }
-//TODO: Remove introduced TODO comments and run formatter
+  // TODO: Remove introduced TODO comments and run formatter
 };
 
 void SubhaloSnapshot_t::MaskSubhalos()

--- a/src/subhalo_unbind.cpp
+++ b/src/subhalo_unbind.cpp
@@ -307,6 +307,7 @@ void Subhalo_t::Unbind(const Snapshot_t &epoch)
   }
   if (Particles.size() == 1)
   {
+    MostBoundParticleId = Particles[0].Id;
     Nbound = 1;
     CountParticles();
 #ifdef SAVE_BINDING_ENERGY

--- a/src/subhalo_unbind.cpp
+++ b/src/subhalo_unbind.cpp
@@ -307,7 +307,6 @@ void Subhalo_t::Unbind(const Snapshot_t &epoch)
   }
   if (Particles.size() == 1)
   {
-    MostBoundParticleId = Particles[0].Id;
     Nbound = 1;
     CountParticles();
 #ifdef SAVE_BINDING_ENERGY

--- a/testing/compile.sh
+++ b/testing/compile.sh
@@ -1,6 +1,6 @@
 # Load modules used for compiling
 module purge
-module load gnu_comp/11.1.0 hdf5/1.12.0 openmpi/4.1.1 cmake/3.25.1
+module load gnu_comp/13.1.0 hdf5/1.12.2 openmpi/4.1.4 cmake/3.28.3
 
 # Location of executable
 rm -fr build # In case an older version is already present

--- a/testing/config_test.txt
+++ b/testing/config_test.txt
@@ -4,7 +4,7 @@
 [Compulsary Params]
 SnapshotPath /cosma7/data/dp004/dc-foro1/colibre/ 
 HaloPath /cosma7/data/dp004/dc-foro1/colibre/
-SubhaloPath hbt_output
+SubhaloPath
 SnapshotFileBase colibre
 
 # These should be read in from swiftsim automatically

--- a/testing/run_test.sh
+++ b/testing/run_test.sh
@@ -6,5 +6,6 @@ then
 else
     rm -rf test_output # Remove to prevent partially overwritting previous tests.
     bash compile.sh
+    mkdir -p test_output/logs
     sbatch submit_test.sh
 fi

--- a/testing/run_test.sh
+++ b/testing/run_test.sh
@@ -4,8 +4,9 @@ if [[ $(hostname) != *"login7"* ]]
 then
     echo "Trying to run test in a non-COSMA7 login node. Please switch to COSMA7."
 else
-    rm -rf test_output # Remove to prevent partially overwritting previous tests.
+    OUTPUTDIR=${1:-$PWD\/test_output}
+    rm -rf $OUTPUTDIR # Remove to prevent partially overwritting previous tests.
     bash compile.sh
-    mkdir -p test_output/logs
-    sbatch submit_test.sh
+    mkdir -p $OUTPUTDIR/logs
+    sbatch --export=OUTPUTDIR=$OUTPUTDIR --output $OUTPUTDIR/logs/output.out --error $OUTPUTDIR/logs/error.err submit_test.sh
 fi

--- a/testing/submit_test.sh
+++ b/testing/submit_test.sh
@@ -20,13 +20,13 @@ echo
 
 # Need to do this so that the catalogue parameter file reflects the absolute path.
 # Otherwise the HBT reader will not work.
-sed -i "s|hbt_output|$OUTPUTDIR|g" config_test.txt
+sed -i "/.*SubhaloPath.*/c\SubhaloPath ${OUTPUTDIR}" config_test.txt
 
 export OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK
 mpirun $RP_OPENMPI_ARGS -np $SLURM_NTASKS ./build/HBT config_test.txt
 
 # Revert to the original value of the path
-sed -i "s|$OUTPUTDIR|hbt_output|g" config_test.txt
+sed -i '/.*SubhaloPath.*/c\SubhaloPath' config_test.txt
 
 echo
 echo "Job complete."

--- a/testing/submit_test.sh
+++ b/testing/submit_test.sh
@@ -5,12 +5,13 @@
 #SBATCH -J HBT_TEST
 #SBATCH -o %x.%J.out
 #SBATCH -e %x.%J.err
-#SBATCH -p cosma7
+#SBATCH -p cosma7-rp
 #SBATCH -A dp004
 #SBATCH -t 00:20:00
 
 module purge
-module load gnu_comp/11.1.0 hdf5/1.12.0 openmpi/4.1.1
+module load gnu_comp/13.1.0 hdf5/1.12.2 openmpi/4.1.4
+module load rockport-settings
 
 echo
 echo "Running on hosts: $SLURM_NODELIST"
@@ -24,7 +25,7 @@ echo
 sed -i "s|hbt_output|$PWD\/test_output|g" config_test.txt
 
 export OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK
-mpirun -np $SLURM_NTASKS ./build/HBT config_test.txt
+mpirun $RP_OPENMPI_ARGS -np $SLURM_NTASKS ./build/HBT config_test.txt
 
 # Revert to the original value of the path
 sed -i "s|$PWD\/test_output|hbt_output|g" config_test.txt

--- a/testing/submit_test.sh
+++ b/testing/submit_test.sh
@@ -3,8 +3,8 @@
 #SBATCH --ntasks 2
 #SBATCH --cpus-per-task=14
 #SBATCH -J HBT_TEST
-#SBATCH -o %x.%J.out
-#SBATCH -e %x.%J.err
+#SBATCH -o test_output/logs/%x.%J.out
+#SBATCH -e test_output/logs/%x.%J.err
 #SBATCH -p cosma7-rp
 #SBATCH -A dp004
 #SBATCH -t 00:20:00

--- a/testing/submit_test.sh
+++ b/testing/submit_test.sh
@@ -3,8 +3,6 @@
 #SBATCH --ntasks 2
 #SBATCH --cpus-per-task=14
 #SBATCH -J HBT_TEST
-#SBATCH -o test_output/logs/%x.%J.out
-#SBATCH -e test_output/logs/%x.%J.err
 #SBATCH -p cosma7-rp
 #SBATCH -A dp004
 #SBATCH -t 00:20:00
@@ -22,10 +20,14 @@ echo
 
 # Need to do this so that the catalogue parameter file reflects the absolute path.
 # Otherwise the HBT reader will not work.
-sed -i "s|hbt_output|$PWD\/test_output|g" config_test.txt
+sed -i "s|hbt_output|$OUTPUTDIR|g" config_test.txt
 
 export OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK
 mpirun $RP_OPENMPI_ARGS -np $SLURM_NTASKS ./build/HBT config_test.txt
 
 # Revert to the original value of the path
-sed -i "s|$PWD\/test_output|hbt_output|g" config_test.txt
+sed -i "s|$OUTPUTDIR|hbt_output|g" config_test.txt
+
+echo
+echo "Job complete."
+echo


### PR DESCRIPTION
This change checks whether all particles have been removed during the masking step. If so then a tracer is added back in. I am not converting the subhalo to an orphan at this point, but since it will have only one tracer it will be converted to an orphan in subhalo_unbind anyway.

When masking is called the TracerIndex of a subhalo may be incorrect. I think this is due to gas particles which formed stars being removed by KickNullParticles during particle exchange. I therefore have to locate the first tracer as part of this change. If Victor's changes guarantee that TracerIndex is correct, then I can remove this step from my changes.

I have been able to run this on Flamingo L1000N0900/HYDRO_FIDUCIAL with the CHECK_TRACER_INDEX compile option enabled.

I'll need to remove some comments and run the formatter before merging.