### PR TITLE
Constrain subhalo particles to assigned FOF host

### DIFF
--- a/HBT.cpp
+++ b/HBT.cpp
@@ -101,7 +101,7 @@ int main(int argc, char **argv)
      * are the centrals. Centrals get assigned all the particles in the FOF that
      * do not belong to secondary subhaloes. All particles belonging to a
      * secondary subhalo are constrained to be within the FOF assigned to the
-     * subhalo they belong to. */
+     * subhalo they belong to. Constraint not applied if particles are fof-less.*/
     timer.Tick(world.Communicator);
     subsnap.AssignHosts(world, halosnap, partsnap);
     subsnap.PrepareCentrals(world, halosnap);

--- a/HBT.cpp
+++ b/HBT.cpp
@@ -97,13 +97,18 @@ int main(int argc, char **argv)
     // Don't need the particle data after this point, so save memory
     partsnap.ClearParticles();
 
+    /* We assign a FOF host to every pre-existing subhalo, and decide which ones
+     * are the centrals. Centrals get assigned all the particles in the FOF that
+     * do not belong to secondary subhaloes. All particles belonging to a 
+     * secondary subhalo are constrained to be within the FOF assigned to the
+     * subhalo they belong to. */
     timer.Tick(world.Communicator);
     subsnap.AssignHosts(world, halosnap, partsnap);
     subsnap.PrepareCentrals(world, halosnap);
 
     timer.Tick(world.Communicator);
     if (world.rank() == 0)
-      cout << "unbinding...\n";
+      cout << "Unbinding...\n";
     subsnap.RefineParticles();
 
     timer.Tick(world.Communicator);

--- a/HBT.cpp
+++ b/HBT.cpp
@@ -72,9 +72,13 @@ int main(int argc, char **argv)
   for (int isnap = snapshot_start; isnap <= snapshot_end; isnap++)
   {
     timer.Tick(world.Communicator);
+
+    /* Load particle information */
     ParticleSnapshot_t partsnap;
     partsnap.Load(world, isnap);
     subsnap.SetSnapshotIndex(isnap);
+
+    /* Load FOF group information */
     HaloSnapshot_t halosnap;
     halosnap.Load(world, isnap);
 

--- a/HBT.cpp
+++ b/HBT.cpp
@@ -99,7 +99,7 @@ int main(int argc, char **argv)
 
     /* We assign a FOF host to every pre-existing subhalo, and decide which ones
      * are the centrals. Centrals get assigned all the particles in the FOF that
-     * do not belong to secondary subhaloes. All particles belonging to a 
+     * do not belong to secondary subhaloes. All particles belonging to a
      * secondary subhalo are constrained to be within the FOF assigned to the
      * subhalo they belong to. */
     timer.Tick(world.Communicator);

--- a/src/config_parser.cpp
+++ b/src/config_parser.cpp
@@ -310,7 +310,7 @@ void Parameter_t::BroadCast(MpiWorker_t &world, int root)
   _SyncReal(TreeNodeResolutionHalf);
   _SyncReal(BoxHalf);
 
-  _SyncAtom(ParticleGroupNullId,
+  _SyncAtom(ParticleNullGroupId,
             MPI_HBT_INT); // Sync here for consistency, but uninitialised until read from snapshots.
 
   _SyncBool(GroupLoadedFullParticle);

--- a/src/config_parser.cpp
+++ b/src/config_parser.cpp
@@ -310,7 +310,8 @@ void Parameter_t::BroadCast(MpiWorker_t &world, int root)
   _SyncReal(TreeNodeResolutionHalf);
   _SyncReal(BoxHalf);
 
-  _SyncAtom(ParticleGroupNullId, MPI_HBT_INT); // Sync here for consistency, but uninitialised until read from snapshots.
+  _SyncAtom(ParticleGroupNullId,
+            MPI_HBT_INT); // Sync here for consistency, but uninitialised until read from snapshots.
 
   _SyncBool(GroupLoadedFullParticle);
   _SyncAtom(TracerParticleBitMask, MPI_INT);

--- a/src/config_parser.cpp
+++ b/src/config_parser.cpp
@@ -310,6 +310,8 @@ void Parameter_t::BroadCast(MpiWorker_t &world, int root)
   _SyncReal(TreeNodeResolutionHalf);
   _SyncReal(BoxHalf);
 
+  _SyncAtom(ParticleGroupNullId, MPI_HBT_INT); // Sync here for consistency, but uninitialised until read from snapshots.
+
   _SyncBool(GroupLoadedFullParticle);
   _SyncAtom(TracerParticleBitMask, MPI_INT);
   //---------------end sync params-------------------------//

--- a/src/config_parser.h
+++ b/src/config_parser.h
@@ -69,7 +69,7 @@ public:
   HBTReal TreeAllocFactor;
   HBTReal TreeNodeOpenAngle;
   HBTInt TreeMinNumOfCells;
-  HBTInt ParticleGroupNullId; // SWIFT reads this as an int, so we cannot overflow
+  HBTInt ParticleNullGroupId; // SWIFT reads this as an int, so we cannot overflow
 
   HBTInt MaxSampleSizeOfPotentialEstimate;
   bool RefineMostboundParticle; // whether to further improve mostbound particle accuracy in case a

--- a/src/config_parser.h
+++ b/src/config_parser.h
@@ -69,6 +69,7 @@ public:
   HBTReal TreeAllocFactor;
   HBTReal TreeNodeOpenAngle;
   HBTInt TreeMinNumOfCells;
+  HBTInt ParticleGroupNullId; // SWIFT reads this as an int, so we cannot overflow
 
   HBTInt MaxSampleSizeOfPotentialEstimate;
   bool RefineMostboundParticle; // whether to further improve mostbound particle accuracy in case a

--- a/src/io/swiftsim_io.cpp
+++ b/src/io/swiftsim_io.cpp
@@ -691,7 +691,7 @@ void SwiftSimReader_t::LoadSnapshot(MpiWorker_t &world, int snapshotId, vector<P
 
   /* This will be used to determine which particles are hostless when
    * constraining subhaloes to their assigned hosts. */
-  HBTConfig.ParticleGroupNullId = Header.NullGroupId;
+  HBTConfig.ParticleNullGroupId = Header.NullGroupId;
 
   // Decide how many particles this MPI rank will read
   HBTInt np_total = accumulate(np_file.begin(), np_file.end(), (HBTInt)0);

--- a/src/io/swiftsim_io.cpp
+++ b/src/io/swiftsim_io.cpp
@@ -52,7 +52,7 @@ void create_SwiftSimHeader_MPI_type(MPI_Datatype &dtype)
   RegisterAttr(mass_conversion, MPI_DOUBLE, 1);
   RegisterAttr(velocity_conversion, MPI_DOUBLE, 1);
   RegisterAttr(energy_conversion, MPI_DOUBLE, 1);
-  RegisterAttr(NullGroupId, MPI_INTEGER, 1);
+  RegisterAttr(NullGroupId, MPI_HBT_INT, 1);
   RegisterAttr(DM_comoving_softening, MPI_DOUBLE, 1);
   RegisterAttr(DM_maximum_physical_softening, MPI_DOUBLE, 1);
   RegisterAttr(baryon_comoving_softening, MPI_DOUBLE, 1);
@@ -163,7 +163,7 @@ void SwiftSimReader_t::ReadHeader(int ifile, SwiftSimHeader_t &header)
   /* Read group ID used to indicate that a particle is in no FoF group */
   string buf;
   ReadAttribute(file, "Parameters", "FOF:group_id_default", buf);
-  Header.NullGroupId = std::stoi(buf);
+  Header.NullGroupId = (HBTInt)std::stoll(buf);
 
   /* Compute conversion from SWIFT's unit system to HBT's unit system (apart from any a factors) */
   Header.length_conversion = (length_cgs / (1.0e6 * parsec_cgs)) * Header.h / HBTConfig.LengthInMpch;

--- a/src/io/swiftsim_io.cpp
+++ b/src/io/swiftsim_io.cpp
@@ -451,7 +451,7 @@ void SwiftSimReader_t::ReadSnapshot(int ifile, Particle_t *ParticlesInFile, HBTI
   H5Fclose(file);
 }
 
-void SwiftSimReader_t::ReadGroupParticles(int ifile, SwiftParticleHost_t *ParticlesInFile, HBTInt file_start,
+void SwiftSimReader_t::ReadGroupParticles(int ifile, Particle_t *ParticlesInFile, HBTInt file_start,
                                           HBTInt file_count, bool FlagReadParticleId)
 {
   hid_t file = OpenFile(ifile);
@@ -811,7 +811,7 @@ void SwiftSimReader_t::LoadSnapshot(MpiWorker_t &world, int snapshotId, vector<P
 #endif
 }
 
-inline bool CompParticleHost(const SwiftParticleHost_t &a, const SwiftParticleHost_t &b)
+inline bool CompParticleHost(const Particle_t &a, const Particle_t &b)
 {
   return a.HostId < b.HostId;
 }
@@ -856,7 +856,7 @@ void SwiftSimReader_t::LoadGroups(MpiWorker_t &world, int snapshotId, vector<Hal
   assert(local_last_offset < np_total);
 
   // Allocate storage for the particles
-  vector<SwiftParticleHost_t> ParticleHosts;
+  vector<Particle_t> ParticleHosts;
   ParticleHosts.resize(np_local);
 
   bool FlagReadId = true; //! HBTConfig.GroupLoadedIndex;

--- a/src/io/swiftsim_io.cpp
+++ b/src/io/swiftsim_io.cpp
@@ -11,7 +11,7 @@ using namespace std;
 #include <sstream>
 #include <string>
 #include <typeinfo>
-
+#include <stdexcept>
 #include "../config_parser.h"
 #include "../hdf_wrapper.h"
 #include "../mymath.h"
@@ -163,7 +163,11 @@ void SwiftSimReader_t::ReadHeader(int ifile, SwiftSimHeader_t &header)
   /* Read group ID used to indicate that a particle is in no FoF group */
   string buf;
   ReadAttribute(file, "Parameters", "FOF:group_id_default", buf);
-  Header.NullGroupId = (HBTInt)std::stoll(buf);
+  // Check if using HBTInt would not overflow value 
+  long long NullGroupId = std::stoll(buf);
+  if(NullGroupId > std::numeric_limits<HBTInt>::max())
+    throw std::overflow_error("The precision of HBTInt is insufficient to hold the value of NullGroupId");
+  Header.NullGroupId = (HBTInt)NullGroupId;
 
   /* Compute conversion from SWIFT's unit system to HBT's unit system (apart from any a factors) */
   Header.length_conversion = (length_cgs / (1.0e6 * parsec_cgs)) * Header.h / HBTConfig.LengthInMpch;

--- a/src/io/swiftsim_io.cpp
+++ b/src/io/swiftsim_io.cpp
@@ -689,6 +689,10 @@ void SwiftSimReader_t::LoadSnapshot(MpiWorker_t &world, int snapshotId, vector<P
   HBTConfig.TreeNodeResolution = HBTConfig.SofteningHalo * 0.1;
   HBTConfig.TreeNodeResolutionHalf = HBTConfig.TreeNodeResolution / 2.;
 
+  /* This will be used to determine which particles are hostless when 
+   * constraining subhaloes to their assigned hosts. */
+  HBTConfig.ParticleGroupNullId = Header.NullGroupId;
+
   // Decide how many particles this MPI rank will read
   HBTInt np_total = accumulate(np_file.begin(), np_file.end(), (HBTInt)0);
   HBTInt np_local = np_total / world.size();

--- a/src/io/swiftsim_io.cpp
+++ b/src/io/swiftsim_io.cpp
@@ -443,7 +443,7 @@ void SwiftSimReader_t::ReadSnapshot(int ifile, Particle_t *ParticlesInFile, HBTI
           ParticlesToRead[offset + i].HostId = id[i];
       }
     }
-  
+
     // Advance to next particle type
     H5Gclose(particle_data);
     ParticlesToRead += read_count;
@@ -689,7 +689,7 @@ void SwiftSimReader_t::LoadSnapshot(MpiWorker_t &world, int snapshotId, vector<P
   HBTConfig.TreeNodeResolution = HBTConfig.SofteningHalo * 0.1;
   HBTConfig.TreeNodeResolutionHalf = HBTConfig.TreeNodeResolution / 2.;
 
-  /* This will be used to determine which particles are hostless when 
+  /* This will be used to determine which particles are hostless when
    * constraining subhaloes to their assigned hosts. */
   HBTConfig.ParticleGroupNullId = Header.NullGroupId;
 

--- a/src/io/swiftsim_io.cpp
+++ b/src/io/swiftsim_io.cpp
@@ -430,6 +430,20 @@ void SwiftSimReader_t::ReadSnapshot(int ifile, Particle_t *ParticlesInFile, HBTI
     }
 #endif
 
+    // Hostid
+    {
+      for (hsize_t offset = 0; offset < read_count; offset += chunksize)
+      {
+        hsize_t count = read_count - offset;
+        if (count > chunksize)
+          count = chunksize;
+        vector<HBTInt> id(count);
+        ReadPartialDataset(particle_data, "FOFGroupIDs", H5T_HBTInt, id.data(), offset + read_offset, count);
+        for (hsize_t i = 0; i < count; i += 1)
+          ParticlesToRead[offset + i].HostId = id[i];
+      }
+    }
+  
     // Advance to next particle type
     H5Gclose(particle_data);
     ParticlesToRead += read_count;

--- a/src/io/swiftsim_io.h
+++ b/src/io/swiftsim_io.h
@@ -40,9 +40,10 @@ struct SwiftSimHeader_t
 
 void create_SwiftSimHeader_MPI_type(MPI_Datatype &dtype);
 
+// Dummy struct at the moment. Remove in future if neccessary.
 struct SwiftParticleHost_t : public Particle_t
 {
-  HBTInt HostId;
+  // HBTInt HostId;
 };
 
 class SwiftSimReader_t

--- a/src/io/swiftsim_io.h
+++ b/src/io/swiftsim_io.h
@@ -31,7 +31,7 @@ struct SwiftSimHeader_t
   double mass_conversion;
   double velocity_conversion;
   double energy_conversion;
-  int NullGroupId;
+  HBTInt NullGroupId;
   double DM_comoving_softening;
   double DM_maximum_physical_softening;
   double baryon_comoving_softening;         // NOTE: currently being loaded but unused

--- a/src/io/swiftsim_io.h
+++ b/src/io/swiftsim_io.h
@@ -40,12 +40,6 @@ struct SwiftSimHeader_t
 
 void create_SwiftSimHeader_MPI_type(MPI_Datatype &dtype);
 
-// Dummy struct at the moment. Remove in future if neccessary.
-struct SwiftParticleHost_t : public Particle_t
-{
-  // HBTInt HostId;
-};
-
 class SwiftSimReader_t
 {
   string SnapshotName;
@@ -57,7 +51,7 @@ class SwiftSimReader_t
   void ReadUnits(HBTReal &MassInMsunh, HBTReal &LengthInMpch, HBTReal &VelInKmS);
   HBTInt CompileFileOffsets(int nfiles);
   void ReadSnapshot(int ifile, Particle_t *ParticlesInFile, HBTInt file_start, HBTInt file_count);
-  void ReadGroupParticles(int ifile, SwiftParticleHost_t *ParticlesInFile, HBTInt file_start, HBTInt file_count,
+  void ReadGroupParticles(int ifile, Particle_t *ParticlesInFile, HBTInt file_start, HBTInt file_count,
                           bool FlagReadParticleId);
   void GetFileName(int ifile, string &filename);
   void SetSnapshot(int snapshotId);

--- a/src/particle_exchanger.cpp
+++ b/src/particle_exchanger.cpp
@@ -24,6 +24,7 @@ void create_Mpi_RemoteParticleType(MPI_Datatype &dtype)
     i++;                                                                                                               \
   }
   RegisterAttr(Id, MPI_HBT_INT, 1);
+  RegisterAttr(HostId, MPI_HBT_INT, 1);
   RegisterAttr(ComovingPosition, MPI_HBT_REAL, 3);
   RegisterAttr(PhysicalVelocity, MPI_HBT_VEL, 3);
   RegisterAttr(Mass, MPI_HBT_MASS, 1);

--- a/src/snapshot.cpp
+++ b/src/snapshot.cpp
@@ -161,6 +161,7 @@ void Particle_t::create_MPI_type(MPI_Datatype &dtype)
     i++;                                                                                                               \
   }
   RegisterAttr(Id, MPI_HBT_INT, 1);
+  RegisterAttr(HostId, MPI_HBT_INT, 1);
   RegisterAttr(ComovingPosition, MPI_HBT_REAL, 3);
   RegisterAttr(PhysicalVelocity, MPI_HBT_VEL, 3);
   RegisterAttr(Mass, MPI_HBT_MASS, 1);

--- a/src/snapshot.h
+++ b/src/snapshot.h
@@ -62,6 +62,7 @@ struct Particle_t
 #endif
   ParticleType_t Type;
 #endif
+  HBTInt HostId;
   void create_MPI_type(MPI_Datatype &dtype);
   Particle_t(){};
   Particle_t(HBTInt id) : Id(id)

--- a/src/subhalo.h
+++ b/src/subhalo.h
@@ -125,6 +125,7 @@ public:
   void RecursiveUnbind(SubhaloList_t &Subhalos, const Snapshot_t &snap);
   HBTReal KineticDistance(const Halo_t &halo, const Snapshot_t &epoch);
   void TruncateSource();
+  void RemoveOtherHostParticles(const HBTInt &GlobalHostHaloId);
   float GetMass() const
   {
     return Mbound; // accumulate(begin(MboundType), end(MboundType), (HBTReal)0.);
@@ -295,6 +296,7 @@ public:
   //   void ParticleIndexToId();
   void UpdateMostBoundPosition(MpiWorker_t &world, const ParticleSnapshot_t &part_snap);
   void AssignHosts(MpiWorker_t &world, HaloSnapshot_t &halo_snap, const ParticleSnapshot_t &part_snap);
+  void ConstrainToSingleHost(const HaloSnapshot_t &halo_snap);
   void PrepareCentrals(MpiWorker_t &world, HaloSnapshot_t &halo_snap);
   void RefineParticles();
   void UpdateTracks(MpiWorker_t &world, const HaloSnapshot_t &halo_snap);

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -645,36 +645,37 @@ void SubhaloSnapshot_t::AssignHosts(MpiWorker_t &world, HaloSnapshot_t &halo_sna
 
   MemberTable.Build(halo_snap.Halos.size(), Subhalos, true);
 
-  /* We constrain particles to belong to FOF that hosts the subhalo they are 
+  /* We constrain particles to belong to FOF that hosts the subhalo they are
    * associated to. */
   ConstrainToSingleHost(halo_snap);
 }
 
-/* Constrains subhaloes to only exist within a single host. This prevents 
+/* Constrains subhaloes to only exist within a single host. This prevents
  * particles from belonging to more than duplications from occuring. */
 void SubhaloSnapshot_t::ConstrainToSingleHost(const HaloSnapshot_t &halo_snap)
 {
-  /* Remove particles assigned to a host different to the one assigned to the 
-   * subhalo. Need to pass entry from halo_snap.Halos, because HostHaloId in 
+  /* Remove particles assigned to a host different to the one assigned to the
+   * subhalo. Need to pass entry from halo_snap.Halos, because HostHaloId in
    * subhalos is local value, rather than global. */
 #pragma omp parallel for schedule(dynamic, 1) if (ParallelizeHaloes)
   for (HBTInt subid = 0; subid < Subhalos.size(); subid++)
-      Subhalos[subid].RemoveOtherHostParticles(halo_snap.Halos[Subhalos[subid].HostHaloId].HaloId);
+    Subhalos[subid].RemoveOtherHostParticles(halo_snap.Halos[Subhalos[subid].HostHaloId].HaloId);
 }
 
-/* This will remove from the source of the current subhalo all particles that 
- * belong to a FOF different to the one formally assigned to it, unless the 
+/* This will remove from the source of the current subhalo all particles that
+ * belong to a FOF different to the one formally assigned to it, unless the
  * particle is hostless. We do not need to worry about orphans; they will always
- * be in the host of its tracer at this point. Centrals get applied this 
- * function (since current depth value is not reflective of hierarchy) but the 
+ * be in the host of its tracer at this point. Centrals get applied this
+ * function (since current depth value is not reflective of hierarchy) but the
  * particles get swapped with those of the FOF anyway. */
 void Subhalo_t::RemoveOtherHostParticles(const HBTInt &GlobalHostHaloId)
 {
-  /* Identify (FOF-hosted) particles not present in the one assigned to the 
-   * subgroup. We use NullGroupId rather than -1, since the value is input 
+  /* Identify (FOF-hosted) particles not present in the one assigned to the
+   * subgroup. We use NullGroupId rather than -1, since the value is input
    * dependent. */
-  auto foreign_particles = std::remove_if(Particles.begin(), Particles.end(), [&](Particle_t const &particle) \
-  {return (particle.HostId != (GlobalHostHaloId)) && (particle.HostId != HBTConfig.ParticleGroupNullId); });
+  auto foreign_particles = std::remove_if(Particles.begin(), Particles.end(), [&](Particle_t const &particle) {
+    return (particle.HostId != (GlobalHostHaloId)) && (particle.HostId != HBTConfig.ParticleGroupNullId);
+  });
 
   /* Remove from vector */
   Particles.erase(foreign_particles, Particles.end());

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -651,7 +651,9 @@ void SubhaloSnapshot_t::AssignHosts(MpiWorker_t &world, HaloSnapshot_t &halo_sna
 }
 
 /* Constrains subhaloes to only exist within a single host. This prevents
- * particles from belonging to more than duplications from occuring. */
+ * duplications from occuring as a result of this. For example, a particle 
+ * associated to a satellite subhalo that is in a different FOF, hence being 
+ * fed to its corresponding central. */
 void SubhaloSnapshot_t::ConstrainToSingleHost(const HaloSnapshot_t &halo_snap)
 {
   /* Remove particles assigned to a host different to the one assigned to the

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -644,7 +644,43 @@ void SubhaloSnapshot_t::AssignHosts(MpiWorker_t &world, HaloSnapshot_t &halo_sna
   halo_snap.ClearParticleHash();
 
   MemberTable.Build(halo_snap.Halos.size(), Subhalos, true);
-  //   MemberTable.AssignRanks(Subhalos); //not needed here
+
+  /* We constrain particles to belong to FOF that hosts the subhalo they are 
+   * associated to. */
+  ConstrainToSingleHost(halo_snap);
+}
+
+/* Constrains subhaloes to only exist within a single host. This prevents 
+ * particles from belonging to more than duplications from occuring. */
+void SubhaloSnapshot_t::ConstrainToSingleHost(const HaloSnapshot_t &halo_snap)
+{
+  /* Remove particles assigned to a host different to the one assigned to the 
+   * subhalo. Need to pass entry from halo_snap.Halos, because HostHaloId in 
+   * subhalos is local value, rather than global. */
+#pragma omp parallel for schedule(dynamic, 1) if (ParallelizeHaloes)
+  for (HBTInt subid = 0; subid < Subhalos.size(); subid++)
+      Subhalos[subid].RemoveOtherHostParticles(halo_snap.Halos[Subhalos[subid].HostHaloId].HaloId);
+}
+
+/* This will remove from the source of the current subhalo all particles that 
+ * belong to a FOF different to the one formally assigned to it, unless the 
+ * particle is hostless. We do not need to worry about orphans; they will always
+ * be in the host of its tracer at this point. Centrals get applied this 
+ * function (since current depth value is not reflective of hierarchy) but the 
+ * particles get swapped with those of the FOF anyway. */
+void Subhalo_t::RemoveOtherHostParticles(const HBTInt &GlobalHostHaloId)
+{
+  /* Identify (FOF-hosted) particles not present in the one assigned to the 
+   * subgroup. We use NullGroupId rather than -1, since the value is input 
+   * dependent. */
+  auto foreign_particles = std::remove_if(Particles.begin(), Particles.end(), [&](Particle_t const &particle) \
+  {return (particle.HostId != (GlobalHostHaloId)) && (particle.HostId != 2147483647); });
+
+  /* Remove from vector */
+  Particles.erase(foreign_particles, Particles.end());
+
+  /* Update number of particles in the source */
+  Nbound = Particles.size();
 }
 
 void SubhaloSnapshot_t::DecideCentrals(const HaloSnapshot_t &halo_snap)

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -674,7 +674,7 @@ void Subhalo_t::RemoveOtherHostParticles(const HBTInt &GlobalHostHaloId)
    * subgroup. We use NullGroupId rather than -1, since the value is input 
    * dependent. */
   auto foreign_particles = std::remove_if(Particles.begin(), Particles.end(), [&](Particle_t const &particle) \
-  {return (particle.HostId != (GlobalHostHaloId)) && (particle.HostId != 2147483647); });
+  {return (particle.HostId != (GlobalHostHaloId)) && (particle.HostId != HBTConfig.ParticleGroupNullId); });
 
   /* Remove from vector */
   Particles.erase(foreign_particles, Particles.end());

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -676,7 +676,7 @@ void Subhalo_t::RemoveOtherHostParticles(const HBTInt &GlobalHostHaloId)
    * subgroup. We use NullGroupId rather than -1, since the value is input
    * dependent. */
   auto foreign_particles = std::remove_if(Particles.begin(), Particles.end(), [&](Particle_t const &particle) {
-    return (particle.HostId != (GlobalHostHaloId)) && (particle.HostId != HBTConfig.ParticleGroupNullId);
+    return (particle.HostId != (GlobalHostHaloId)) && (particle.HostId != HBTConfig.ParticleNullGroupId);
   });
 
   /* Remove from vector */

--- a/testing/check_interhost_subhalos.py
+++ b/testing/check_interhost_subhalos.py
@@ -1,0 +1,279 @@
+#!/bin/env python
+from tqdm import tqdm
+from mpi4py import MPI
+comm = MPI.COMM_WORLD
+comm_rank = comm.Get_rank()
+comm_size = comm.Get_size()
+
+import h5py
+import numpy as np
+
+import virgo.mpi.util
+import virgo.mpi.parallel_hdf5 as phdf5
+import virgo.mpi.parallel_sort as psort
+
+def read_snapshot(snapshot_file, snap_nr, particle_ids):
+    """
+    Read particle properties for the specified particle IDs.
+    Returns a dict of arrays.
+    """
+
+    # Datasets to pass through from the snapshot
+    passthrough_datasets = ("FOFGroupIDs",)
+    
+    # Sub in the snapshot number
+    from virgo.util.partial_formatter import PartialFormatter
+    formatter = PartialFormatter()
+    filenames = formatter.format(snapshot_file, snap_nr=snap_nr, file_nr=None)
+
+    # Determine what particle types we have in the snapshot
+    if comm_rank == 0:
+        ptypes = []
+        with h5py.File(filenames.format(file_nr=0), "r") as infile:
+            nr_types = int(infile["Header"].attrs["NumPartTypes"])
+            nr_parts = infile["Header"].attrs["NumPart_Total"]
+            nr_parts_hw = infile["Header"].attrs["NumPart_Total_HighWord"]
+            for i in range(nr_types):
+                if nr_parts[i] > 0 or nr_parts_hw[i] > 0:
+                    ptypes.append(i)
+    else:
+        ptypes = None
+    ptypes = comm.bcast(ptypes)
+
+    # Read the particle data from the snapshot
+    particle_data = {"Type" : -np.ones(particle_ids.shape, dtype=np.int32)}
+    mf = phdf5.MultiFile(filenames, file_nr_attr=("Header","NumFilesPerSnapshot"), comm=comm)
+    for ptype in ptypes:
+        if ptype == 6:
+            continue # skip neutrinos
+        # Read the IDs of this particle type
+        if comm_rank == 0:
+            print(f"Reading snapshot particle IDs for type {ptype}")
+        snapshot_ids = mf.read(f"PartType{ptype}/ParticleIDs")
+        # For each subhalo particle ID, find matching index in the snapshot (if any)
+        ptr = psort.parallel_match(particle_ids, snapshot_ids, comm=comm)
+        matched = (ptr>=0)
+        # Loop over particle properties to pass through
+        for name in passthrough_datasets:
+            # Read this property from the snapshot
+            snapshot_data = mf.read(f"PartType{ptype}/{name}")
+            # Allocate output array, if we didn't already
+            if name not in particle_data:
+                shape = (len(particle_ids),)+snapshot_data.shape[1:]
+                dtype = snapshot_data.dtype
+                particle_data[name] = -np.ones(shape, dtype=dtype) # initialize to -1 = not found
+            # Look up the value for each subhalo particle
+            # if comm_rank == 0:
+                # print(f"Looking up particle type {ptype} property {name} from snapshot")
+            particle_data[name][matched,...] = psort.fetch_elements(snapshot_data, ptr[matched], comm=comm)
+        
+        # Also store the type of each matched particle
+        particle_data["Type"][matched] = ptype
+
+    # Should have matched all particles, except for merged black holes 
+    # assert np.all(particle_data["Type"] >= 0)
+        
+    return particle_data
+    
+
+def read_source_particles(filenames, nr_local_subhalos, nr_files):
+    """
+    Read in the particle IDs belonging to the subhalos on this MPI
+    rank from the specified SubSnap files. Returns a single array with
+    the concatenated IDs from all local subhalos in the order they
+    appear in the SubSnap files.
+    """
+
+    # First determine how many subhalos are in each SubSnap file
+    if comm_rank == 0:
+        subhalos_per_file = []
+        file_nr = 0
+        while file_nr < nr_files:
+            with h5py.File(filenames.format(file_nr=file_nr), "r") as infile:
+                subhalos_per_file.append(infile["SrchaloParticles"].shape[0])
+            file_nr += 1
+    else:
+        subhalos_per_file = None
+        nr_files = None
+    
+    nr_files = comm.bcast(nr_files)
+    subhalos_per_file = np.asarray(comm.bcast(subhalos_per_file), dtype=int)
+    first_subhalo_in_file = np.cumsum(subhalos_per_file) - subhalos_per_file
+    print(subhalos_per_file)
+    # Determine offset to first subhalo this rank reads
+    first_local_subhalo = comm.scan(nr_local_subhalos) - nr_local_subhalos
+
+    # Loop over all files
+    particle_ids = []
+    for file_nr in range(nr_files):
+
+        # Find range of subhalos this rank read from this file
+        i1 = first_local_subhalo - first_subhalo_in_file[file_nr]
+        i2 = i1 + nr_local_subhalos
+        i1 = max(0, i1)
+        i2 = min(subhalos_per_file[file_nr], i2)
+
+        # Read subhalo particle IDs, if there are any in this file for this rank
+        if i2 > i1:
+            with h5py.File(filenames.format(file_nr=file_nr), "r") as infile:
+                particle_ids.append(infile["SrchaloParticles"][i1:i2])
+    
+    Nsource = np.zeros(len(particle_ids[0]), int)
+    for i in range(len(particle_ids[0])):
+        Nsource[i] = len(particle_ids[0][i])
+
+    if len(particle_ids) > 0:
+        # Combine arrays from different files
+        particle_ids = np.concatenate(particle_ids)
+        # Combine arrays from different subhalos
+        particle_ids = np.concatenate(particle_ids)        
+    else:
+        # Some ranks may have read zero files
+        particle_ids = None
+    
+    particle_ids = virgo.mpi.util.replace_none_with_zero_size(particle_ids, comm=comm)
+    
+    # Need to return track ids, since the catalogues do not know Nsource
+    return particle_ids, Nsource
+
+def sort_hbt_output(basedir, hbt_nr, snap_nr, snapshot_file):
+
+    """
+    This reorganizes a set of HBT SubSnap files into a single file which
+    contains one HDF5 dataset for each subhalo property. Subhalos are written
+    in order of TrackId.
+
+    Particle IDs in groups can be optionally copied to the output.
+    """
+    
+    # Read in the input subhalos
+    if comm_rank == 0:
+        print(f"Testing whetehr HBTplus subgroups are contained within their assigned FOF at snapshot index {hbt_nr}")
+        
+    #===========================================================================
+    # Load catalogues for snapshot N 
+    #===========================================================================
+
+    # Make a format string for the filenames
+    filenames = f"{basedir}/{hbt_nr:03d}/SubSnap_{hbt_nr:03d}" + ".{file_nr}.hdf5"
+    if comm_rank ==0:
+        print(f"Opening HBT catalogue: {filenames}", end=' --- ')
+
+    # Open file and load
+    mf = phdf5.MultiFile(filenames, file_nr_dataset="NumberOfFiles", comm=comm)
+    subhalos_before = mf.read("Subhalos")
+    if comm_rank == 0:
+        print("DONE")
+
+    # Find total number of subhalos
+    local_nr_subhalos = len(subhalos_before)
+    total_nr_subhalos = comm.allreduce(local_nr_subhalos)
+
+    # Skip if we do not have any
+    if(total_nr_subhalos == 0):
+        if (comm_rank == 0):
+            print(f"There are no subgroups to trace in snapshot {hbt_nr}. Exiting now.")
+        return
+
+    # Find total number of resolved subhalos
+    local_nr_subhalos_resolved = (subhalos_before['Nbound'] > 1).sum()
+    total_nr_subhalos_resolved = comm.allreduce(local_nr_subhalos_resolved)
+    
+    # Skip if we do not have any
+    if(total_nr_subhalos_resolved == 0):
+        if (comm_rank == 0):
+            print(f"There are no resolved subgroups check in snapshot {hbt_nr}. Exiting now.")
+        return
+
+    # Convert array of structs to dict of arrays
+    field_names = list(subhalos_before.dtype.fields)
+    data = {}
+    for name in field_names:
+        data[name] = np.ascontiguousarray(subhalos_before[name])
+    del subhalos_before
+
+    # Get the number of files...
+    if comm_rank == 0:
+        with h5py.File(filenames.format(file_nr=0), "r") as infile:
+            nr_files = int(infile["NumberOfFiles"][...])
+    else:
+        nr_files = None
+    nr_files = comm.bcast(nr_files)
+
+    # Read the particle IDs belonging to the source of our local subhalos
+    filenames = f"{basedir}/{hbt_nr:03d}/SrcSnap_{hbt_nr:03d}" + ".{file_nr}.hdf5"
+
+    particle_ids, data['Nsource'] = read_source_particles(filenames, local_nr_subhalos, nr_files)    
+
+    #===========================================================================
+    # Readm particle data to obtain the FOF groups.
+    #===========================================================================
+
+    # Read the following outputs
+    if comm_rank == 0:
+        print()
+        print(f"Reading particle information.")
+    
+    particle_data = read_snapshot(snapshot_file, snap_nr, particle_ids)
+    
+    if comm_rank == 0:
+        print(f"Done reading particle information.")
+        print()
+
+
+    #===========================================================================
+    # Check which FOF groups the source of each subhalo belongs to
+    #===========================================================================
+    offset = 0
+    local_incorrect_fof_count = 0
+
+    for i, (subhalo_trackid, subhalo_length) in enumerate(zip(data['TrackId'],data['Nsource'])):
+
+        # Skip orphans
+        if subhalo_length == 0:
+            continue
+
+        # Get particles in source
+        subhalo_particle_fofs  = particle_data["FOFGroupIDs"][offset : offset + subhalo_length]
+        
+        # Which fofs do they belong to?
+        unique_fofs = np.unique(subhalo_particle_fofs)
+
+        # Remove those assigned to the sub
+        unique_fofs = unique_fofs[(unique_fofs != data['HostHaloId'][i]) & (unique_fofs != 2147483647)]
+
+        if len(unique_fofs) != 0:
+            incorrect_fof_count += 1
+
+        offset += subhalo_length
+    
+    if comm_rank == 0:
+        print("DONE")
+
+    #===========================================================================
+    # Compare our results to what HBT says they should be
+    #===========================================================================
+
+    # Check across all ranks
+    total_incorrect_fof_count = comm.allreduce(local_incorrect_fof_count)
+    
+    # Get how many tests we did
+    local_number_checks = (data['Nsource'] > 0).sum()
+    total_number_checks = comm.allreduce(local_number_checks)
+
+    if comm_rank == 0:
+        print(f"{total_incorrect_fof_count} out of {total_number_checks} disagree.")
+
+if __name__ == "__main__":
+
+    from virgo.mpi.util import MPIArgumentParser
+    
+    parser = MPIArgumentParser(comm, description="Reorganize HBTplus SubSnap outputs")
+    parser.add_argument("basedir", type=str, help="Location of the HBTplus output")
+    parser.add_argument("hbt_nr", type=int, help="Index of the HBT output to process")
+    parser.add_argument("snap_nr", type=int, help="Index of the snapshot to process")
+    parser.add_argument("--snapshot-file", type=str, help="Format string for snapshot files (f-string using {snap_nr}, {file_nr})")
+
+    args = parser.parse_args()
+
+    sort_hbt_output(**vars(args))

--- a/testing/check_interhost_subhalos.py
+++ b/testing/check_interhost_subhalos.py
@@ -1,5 +1,10 @@
 #!/bin/env python
-from tqdm import tqdm
+
+# Retrieve helper functions, without having to define an __init__.py 
+import sys
+sys.path.append('../toolbox')
+from helper_functions import read_source_particles, read_snapshot
+
 from mpi4py import MPI
 comm = MPI.COMM_WORLD
 comm_rank = comm.Get_rank()
@@ -12,143 +17,32 @@ import virgo.mpi.util
 import virgo.mpi.parallel_hdf5 as phdf5
 import virgo.mpi.parallel_sort as psort
 
-def read_snapshot(snapshot_file, snap_nr, particle_ids):
+def check_interhost_subhaloes(basedir, hbt_nr, snap_nr, snapshot_file):
     """
-    Read particle properties for the specified particle IDs.
-    Returns a dict of arrays.
-    """
+    This function checks if all the particles associated to a given subhalo are
+    contained within its assigned FOF host, or are hostless.
 
-    # Datasets to pass through from the snapshot
-    passthrough_datasets = ("FOFGroupIDs",)
+    Parameters
+    ----------
+    basedir : str    
+        Location of the HBT catalogues.
+    hbt_nr : int
+        Snapshot index to test.
+    snap_nr : int
+        Snapshot number to test. Not equal to hbt_nr if the catalogues have only
+        been created for a subset of snapshots.
+    snapshot_file : str
+        Path to the snapshots in the form SNAPSHOT_BASE_NAME_{snap_nr:04d}.{file_nr}.hdf5
+
+    Returns
+    -------
+    total_incorrect_fof_count: int
+        Number of particles part of a FOF group that is different to the one
+        assigned to the subhalo they are associated to. 
+    """
     
-    # Sub in the snapshot number
-    from virgo.util.partial_formatter import PartialFormatter
-    formatter = PartialFormatter()
-    filenames = formatter.format(snapshot_file, snap_nr=snap_nr, file_nr=None)
-
-    # Determine what particle types we have in the snapshot
     if comm_rank == 0:
-        ptypes = []
-        with h5py.File(filenames.format(file_nr=0), "r") as infile:
-            nr_types = int(infile["Header"].attrs["NumPartTypes"])
-            nr_parts = infile["Header"].attrs["NumPart_Total"]
-            nr_parts_hw = infile["Header"].attrs["NumPart_Total_HighWord"]
-            for i in range(nr_types):
-                if nr_parts[i] > 0 or nr_parts_hw[i] > 0:
-                    ptypes.append(i)
-    else:
-        ptypes = None
-    ptypes = comm.bcast(ptypes)
-
-    # Read the particle data from the snapshot
-    particle_data = {"Type" : -np.ones(particle_ids.shape, dtype=np.int32)}
-    mf = phdf5.MultiFile(filenames, file_nr_attr=("Header","NumFilesPerSnapshot"), comm=comm)
-    for ptype in ptypes:
-        if ptype == 6:
-            continue # skip neutrinos
-        # Read the IDs of this particle type
-        if comm_rank == 0:
-            print(f"Reading snapshot particle IDs for type {ptype}")
-        snapshot_ids = mf.read(f"PartType{ptype}/ParticleIDs")
-        # For each subhalo particle ID, find matching index in the snapshot (if any)
-        ptr = psort.parallel_match(particle_ids, snapshot_ids, comm=comm)
-        matched = (ptr>=0)
-        # Loop over particle properties to pass through
-        for name in passthrough_datasets:
-            # Read this property from the snapshot
-            snapshot_data = mf.read(f"PartType{ptype}/{name}")
-            # Allocate output array, if we didn't already
-            if name not in particle_data:
-                shape = (len(particle_ids),)+snapshot_data.shape[1:]
-                dtype = snapshot_data.dtype
-                particle_data[name] = -np.ones(shape, dtype=dtype) # initialize to -1 = not found
-            # Look up the value for each subhalo particle
-            # if comm_rank == 0:
-                # print(f"Looking up particle type {ptype} property {name} from snapshot")
-            particle_data[name][matched,...] = psort.fetch_elements(snapshot_data, ptr[matched], comm=comm)
-        
-        # Also store the type of each matched particle
-        particle_data["Type"][matched] = ptype
-
-    # Should have matched all particles, except for merged black holes 
-    # assert np.all(particle_data["Type"] >= 0)
-        
-    return particle_data
-    
-
-def read_source_particles(filenames, nr_local_subhalos, nr_files):
-    """
-    Read in the particle IDs belonging to the subhalos on this MPI
-    rank from the specified SubSnap files. Returns a single array with
-    the concatenated IDs from all local subhalos in the order they
-    appear in the SubSnap files.
-    """
-
-    # First determine how many subhalos are in each SubSnap file
-    if comm_rank == 0:
-        subhalos_per_file = []
-        file_nr = 0
-        while file_nr < nr_files:
-            with h5py.File(filenames.format(file_nr=file_nr), "r") as infile:
-                subhalos_per_file.append(infile["SrchaloParticles"].shape[0])
-            file_nr += 1
-    else:
-        subhalos_per_file = None
-        nr_files = None
-    
-    nr_files = comm.bcast(nr_files)
-    subhalos_per_file = np.asarray(comm.bcast(subhalos_per_file), dtype=int)
-    first_subhalo_in_file = np.cumsum(subhalos_per_file) - subhalos_per_file
-
-    # Determine offset to first subhalo this rank reads
-    first_local_subhalo = comm.scan(nr_local_subhalos) - nr_local_subhalos
-
-    # Loop over all files
-    particle_ids = []
-    for file_nr in range(nr_files):
-
-        # Find range of subhalos this rank read from this file
-        i1 = first_local_subhalo - first_subhalo_in_file[file_nr]
-        i2 = i1 + nr_local_subhalos
-        i1 = max(0, i1)
-        i2 = min(subhalos_per_file[file_nr], i2)
-
-        # Read subhalo particle IDs, if there are any in this file for this rank
-        if i2 > i1:
-            with h5py.File(filenames.format(file_nr=file_nr), "r") as infile:
-                particle_ids.append(infile["SrchaloParticles"][i1:i2])
-    
-    Nsource = np.zeros(len(particle_ids[0]), int)
-    for i in range(len(particle_ids[0])):
-        Nsource[i] = len(particle_ids[0][i])
-
-    if len(particle_ids) > 0:
-        # Combine arrays from different files
-        particle_ids = np.concatenate(particle_ids)
-        # Combine arrays from different subhalos
-        particle_ids = np.concatenate(particle_ids)        
-    else:
-        # Some ranks may have read zero files
-        particle_ids = None
-    
-    particle_ids = virgo.mpi.util.replace_none_with_zero_size(particle_ids, comm=comm)
-    
-    # Need to return track ids, since the catalogues do not know Nsource
-    return particle_ids, Nsource
-
-def sort_hbt_output(basedir, hbt_nr, snap_nr, snapshot_file):
-
-    """
-    This reorganizes a set of HBT SubSnap files into a single file which
-    contains one HDF5 dataset for each subhalo property. Subhalos are written
-    in order of TrackId.
-
-    Particle IDs in groups can be optionally copied to the output.
-    """
-    
-    # Read in the input subhalos
-    if comm_rank == 0:
-        print(f"Testing whetehr HBTplus subgroups are contained within their assigned FOF at snapshot index {hbt_nr}")
+        print(f"Testing whether HBTplus subgroups are contained within their assigned FOF at snapshot index {hbt_nr}")
         
     #===========================================================================
     # Load catalogues for snapshot N 
@@ -214,7 +108,7 @@ def sort_hbt_output(basedir, hbt_nr, snap_nr, snapshot_file):
         print()
         print(f"Reading particle information.")
     
-    particle_data = read_snapshot(snapshot_file, snap_nr, particle_ids)
+    particle_data = read_snapshot(snapshot_file, snap_nr, particle_ids, ('FOFGroupIDs',))
     
     if comm_rank == 0:
         print(f"Done reading particle information.")
@@ -243,7 +137,7 @@ def sort_hbt_output(basedir, hbt_nr, snap_nr, snapshot_file):
         unique_fofs = unique_fofs[(unique_fofs != data['HostHaloId'][i]) & (unique_fofs != 2147483647)]
 
         if len(unique_fofs) != 0:
-            incorrect_fof_count += 1
+            local_incorrect_fof_count += 1
 
         offset += subhalo_length
     
@@ -264,6 +158,8 @@ def sort_hbt_output(basedir, hbt_nr, snap_nr, snapshot_file):
     if comm_rank == 0:
         print(f"{total_incorrect_fof_count} out of {total_number_checks} disagree.")
 
+    return total_incorrect_fof_count
+
 if __name__ == "__main__":
 
     from virgo.mpi.util import MPIArgumentParser
@@ -276,4 +172,4 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    sort_hbt_output(**vars(args))
+    check_interhost_subhaloes(**vars(args))

--- a/testing/check_interhost_subhalos.py
+++ b/testing/check_interhost_subhalos.py
@@ -99,7 +99,7 @@ def read_source_particles(filenames, nr_local_subhalos, nr_files):
     nr_files = comm.bcast(nr_files)
     subhalos_per_file = np.asarray(comm.bcast(subhalos_per_file), dtype=int)
     first_subhalo_in_file = np.cumsum(subhalos_per_file) - subhalos_per_file
-    print(subhalos_per_file)
+
     # Determine offset to first subhalo this rank reads
     first_local_subhalo = comm.scan(nr_local_subhalos) - nr_local_subhalos
 

--- a/testing/check_interhost_subhalos.py
+++ b/testing/check_interhost_subhalos.py
@@ -121,7 +121,7 @@ def check_interhost_subhaloes(basedir, hbt_nr, snap_nr, snapshot_file):
     offset = 0
     local_incorrect_fof_count = 0
 
-    for i, (subhalo_trackid, subhalo_length) in enumerate(zip(data['TrackId'],data['Nsource'])):
+    for i, subhalo_length in enumerate(data['Nsource']):
 
         # Skip orphans
         if subhalo_length == 0:
@@ -141,9 +141,6 @@ def check_interhost_subhaloes(basedir, hbt_nr, snap_nr, snapshot_file):
 
         offset += subhalo_length
     
-    if comm_rank == 0:
-        print("DONE")
-
     #===========================================================================
     # Compare our results to what HBT says they should be
     #===========================================================================

--- a/testing/check_presence_duplicate_particles.py
+++ b/testing/check_presence_duplicate_particles.py
@@ -1,84 +1,40 @@
 #!/bin/env python
-from tqdm import tqdm
+
+# Retrieve helper functions, without having to define an __init__.py 
+import sys
+sys.path.append('../toolbox')
+from helper_functions import read_particles
+
 from mpi4py import MPI
 comm = MPI.COMM_WORLD
 comm_rank = comm.Get_rank()
 comm_size = comm.Get_size()
 
-import h5py
 import numpy as np
-
-import virgo.mpi.util
 import virgo.mpi.parallel_hdf5 as phdf5
 import virgo.mpi.parallel_sort as psort
 import virgo.mpi.gather_array as gather_array
 
-def read_particles(filenames, nr_local_subhalos):
+def check_duplicate_particles(basedir, hbt_nr):
     """
-    Read in the particle IDs belonging to the subhalos on this MPI
-    rank from the specified SubSnap files. Returns a single array with
-    the concatenated IDs from all local subhalos in the order they
-    appear in the SubSnap files.
-    """
+    This function checks for the presence of particles that are bound to more
+    than one HBT subgroup. 
 
-    # First determine how many subhalos are in each SubSnap file
-    if comm_rank == 0:
-        subhalos_per_file = []
-        nr_files = 1
-        file_nr = 0
-        while file_nr < nr_files:
-            with h5py.File(filenames.format(file_nr=file_nr), "r") as infile:
-                subhalos_per_file.append(infile["Subhalos"].shape[0])
-                nr_files = int(infile["NumberOfFiles"][...])
-            file_nr += 1
-    else:
-        subhalos_per_file = None
-        nr_files = None
-    nr_files = comm.bcast(nr_files)
-    subhalos_per_file = np.asarray(comm.bcast(subhalos_per_file), dtype=int)
-    first_subhalo_in_file = np.cumsum(subhalos_per_file) - subhalos_per_file
-    
-    # Determine offset to first subhalo this rank reads
-    first_local_subhalo = comm.scan(nr_local_subhalos) - nr_local_subhalos
+    Parameters
+    ----------
+    basedir: str    
+        Location of the HBT catalogues.
+    hbt_nr : int
+        Snapshot index to test.
 
-    # Loop over all files
-    particle_ids = []
-    for file_nr in range(nr_files):
-
-        # Find range of subhalos this rank read from this file
-        i1 = first_local_subhalo - first_subhalo_in_file[file_nr]
-        i2 = i1 + nr_local_subhalos
-        i1 = max(0, i1)
-        i2 = min(subhalos_per_file[file_nr], i2)
-
-        # Read subhalo particle IDs, if there are any in this file for this rank
-        if i2 > i1:
-            with h5py.File(filenames.format(file_nr=file_nr), "r") as infile:
-                particle_ids.append(infile["SubhaloParticles"][i1:i2])
-
-    if len(particle_ids) > 0:
-        # Combine arrays from different files
-        particle_ids = np.concatenate(particle_ids)
-        # Combine arrays from different subhalos
-        particle_ids = np.concatenate(particle_ids)        
-    else:
-        # Some ranks may have read zero files
-        particle_ids = None
-    particle_ids = virgo.mpi.util.replace_none_with_zero_size(particle_ids, comm=comm)
-    
-    return particle_ids
-
-def sort_hbt_output(basedir, hbt_nr):
-
-    """
-    This reorganizes a set of HBT SubSnap files into a single file which
-    contains one HDF5 dataset for each subhalo property. Subhalos are written
-    in order of TrackId.
-
-    Particle IDs in groups can be optionally copied to the output.
+    Returns
+    -------
+    total_number_duplicates: int
+        Number of particles that are shared bound to more than one subgroup.
+    number_unique_subhalos_with_duplicate_particles : int
+        Number of unique subgroups that share particles.
     """
 
-    # Read in the input subhalos
     if comm_rank == 0:
         print(f"Testing presence of duplicate particles in HBTplus at snapshot index {hbt_nr}.")
 
@@ -150,12 +106,21 @@ def sort_hbt_output(basedir, hbt_nr):
     if comm_rank == 0:
         print(f"{total_number_duplicates} particles out of {total_number_particles} are duplicate.") 
     
-    # Retrieve the tracks that share particles, if any
+    # Retrieve the subhalos that share particles, if any
     if total_number_duplicates != 0:
-        tracks_with_shared_particles = gather_array.allgather_array(particle_trackids[next_particle_ids == particle_ids], comm=comm)
+        # Number of unique subhalos that share particles
+        subhalos_with_shared_particles = gather_array.allgather_array(particle_trackids[next_particle_ids == particle_ids], comm=comm)
+        number_unique_subhalos_with_duplicate_particles = len(np.unique(subhalos_with_shared_particles))
+
+        # Number of subhalos we tested 
         global_number_subhalos = comm.allreduce(local_nr_subhalos)
+        
         if comm_rank == 0:
-           print(f"{len(np.unique(tracks_with_shared_particles))} unique Tracks out of {global_number_subhalos} share particles.")
+           print(f"{number_unique_subhalos_with_duplicate_particles} unique subhalos out of {global_number_subhalos} share particles.")
+    else:
+        number_unique_subhalos_with_duplicate_particles = 0
+
+    return total_number_duplicates, number_unique_subhalos_with_duplicate_particles
 
 if __name__ == "__main__":
 
@@ -167,4 +132,4 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    sort_hbt_output(**vars(args))
+    check_duplicate_particles(**vars(args))

--- a/testing/check_presence_duplicate_particles.py
+++ b/testing/check_presence_duplicate_particles.py
@@ -1,0 +1,170 @@
+#!/bin/env python
+from tqdm import tqdm
+from mpi4py import MPI
+comm = MPI.COMM_WORLD
+comm_rank = comm.Get_rank()
+comm_size = comm.Get_size()
+
+import h5py
+import numpy as np
+
+import virgo.mpi.util
+import virgo.mpi.parallel_hdf5 as phdf5
+import virgo.mpi.parallel_sort as psort
+import virgo.mpi.gather_array as gather_array
+
+def read_particles(filenames, nr_local_subhalos):
+    """
+    Read in the particle IDs belonging to the subhalos on this MPI
+    rank from the specified SubSnap files. Returns a single array with
+    the concatenated IDs from all local subhalos in the order they
+    appear in the SubSnap files.
+    """
+
+    # First determine how many subhalos are in each SubSnap file
+    if comm_rank == 0:
+        subhalos_per_file = []
+        nr_files = 1
+        file_nr = 0
+        while file_nr < nr_files:
+            with h5py.File(filenames.format(file_nr=file_nr), "r") as infile:
+                subhalos_per_file.append(infile["Subhalos"].shape[0])
+                nr_files = int(infile["NumberOfFiles"][...])
+            file_nr += 1
+    else:
+        subhalos_per_file = None
+        nr_files = None
+    nr_files = comm.bcast(nr_files)
+    subhalos_per_file = np.asarray(comm.bcast(subhalos_per_file), dtype=int)
+    first_subhalo_in_file = np.cumsum(subhalos_per_file) - subhalos_per_file
+    
+    # Determine offset to first subhalo this rank reads
+    first_local_subhalo = comm.scan(nr_local_subhalos) - nr_local_subhalos
+
+    # Loop over all files
+    particle_ids = []
+    for file_nr in range(nr_files):
+
+        # Find range of subhalos this rank read from this file
+        i1 = first_local_subhalo - first_subhalo_in_file[file_nr]
+        i2 = i1 + nr_local_subhalos
+        i1 = max(0, i1)
+        i2 = min(subhalos_per_file[file_nr], i2)
+
+        # Read subhalo particle IDs, if there are any in this file for this rank
+        if i2 > i1:
+            with h5py.File(filenames.format(file_nr=file_nr), "r") as infile:
+                particle_ids.append(infile["SubhaloParticles"][i1:i2])
+
+    if len(particle_ids) > 0:
+        # Combine arrays from different files
+        particle_ids = np.concatenate(particle_ids)
+        # Combine arrays from different subhalos
+        particle_ids = np.concatenate(particle_ids)        
+    else:
+        # Some ranks may have read zero files
+        particle_ids = None
+    particle_ids = virgo.mpi.util.replace_none_with_zero_size(particle_ids, comm=comm)
+    
+    return particle_ids
+
+def sort_hbt_output(basedir, hbt_nr):
+
+    """
+    This reorganizes a set of HBT SubSnap files into a single file which
+    contains one HDF5 dataset for each subhalo property. Subhalos are written
+    in order of TrackId.
+
+    Particle IDs in groups can be optionally copied to the output.
+    """
+
+    # Read in the input subhalos
+    if comm_rank == 0:
+        print(f"Testing presence of duplicate particles in HBTplus at snapshot index {hbt_nr}.")
+
+    #===========================================================================
+    # Load catalogues for snapshot N 
+    #===========================================================================
+    
+    # Make a format string for the filenames
+    filenames = f"{basedir}/{hbt_nr:03d}/SubSnap_{hbt_nr:03d}" + ".{file_nr}.hdf5"
+    if comm_rank ==0:
+        print(f"Opening HBT catalogue: {filenames}", end=' --- ')
+
+    # Open file and load
+    mf = phdf5.MultiFile(filenames, file_nr_dataset="NumberOfFiles", comm=comm)
+    subhalos = mf.read("Subhalos")
+
+    field_names = list(subhalos.dtype.fields)
+
+    # Assign TrackIds to the particles
+    particle_trackids = np.repeat(subhalos["TrackId"], subhalos["Nbound"])
+        
+    # Convert array of structs to dict of arrays
+    data = {}
+    for name in field_names:
+        data[name] = np.ascontiguousarray(subhalos[name])
+    del subhalos
+
+    # Find total number of subhalos
+    local_nr_subhalos = len(data['Nbound'])
+
+    # Read the particle IDs in our local subhalos
+    particle_ids = read_particles(filenames, local_nr_subhalos)
+    nbound = data["Nbound"]
+    nr_local_particles = len(particle_ids)
+    assert nr_local_particles == np.sum(nbound)
+
+    if comm_rank == 0:
+        print("DONE")
+
+    #===========================================================================
+    # Sort particles and get the values to compare against
+    #===========================================================================
+
+    # Sort particle ids across tasks
+    order = psort.parallel_sort(particle_ids, return_index=True, comm=comm)
+    particle_trackids = psort.fetch_elements(particle_trackids, order, comm=comm)
+
+    # How many particles are in each rank
+    nr_particles_vector = gather_array.allgather_array(nr_local_particles, comm=comm)
+
+    # Element number to retrieve (the next particle id)
+    element_to_retrieve = np.arange(nr_local_particles) + nr_particles_vector[:comm_rank].sum() + 1
+    
+    # We manually overwrite the last entry in the array of the last rank, as it 
+    # will otherwise try to access out of bounds.
+    if(comm_rank == comm_size - 1):
+        element_to_retrieve[-1] = 0
+
+    # order = np.arange(1, len)
+    next_particle_ids = psort.fetch_elements(particle_ids, element_to_retrieve, comm=comm)
+
+    #===========================================================================
+    # Check for duplicates across all ranks
+    #===========================================================================
+    local_number_duplicates = (next_particle_ids == particle_ids).sum()
+    total_number_duplicates = comm.allreduce(local_number_duplicates)
+    total_number_particles  = comm.allreduce(nr_local_particles)
+    
+    if comm_rank == 0:
+        print(f"{total_number_duplicates} particles out of {total_number_particles} are duplicate.") 
+    
+    # Retrieve the tracks that share particles, if any
+    if total_number_duplicates != 0:
+        tracks_with_shared_particles = gather_array.allgather_array(particle_trackids[next_particle_ids == particle_ids], comm=comm)
+        global_number_subhalos = comm.allreduce(local_nr_subhalos)
+        if comm_rank == 0:
+           print(f"{len(np.unique(tracks_with_shared_particles))} unique Tracks out of {global_number_subhalos} share particles.")
+
+if __name__ == "__main__":
+
+    from virgo.mpi.util import MPIArgumentParser
+    
+    parser = MPIArgumentParser(comm, description="Reorganize HBTplus SubSnap outputs")
+    parser.add_argument("basedir", type=str, help="Location of the HBTplus output")
+    parser.add_argument("hbt_nr", type=int, help="Index of the HBT output to process")
+
+    args = parser.parse_args()
+
+    sort_hbt_output(**vars(args))

--- a/testing/check_tracing_particles_orphan_subgroups.py
+++ b/testing/check_tracing_particles_orphan_subgroups.py
@@ -1,5 +1,10 @@
 #!/bin/env python
-from tqdm import tqdm
+
+# Retrieve helper functions, without having to define an __init__.py 
+import sys
+sys.path.append('../toolbox')
+from helper_functions import read_snapshot
+
 from mpi4py import MPI
 comm = MPI.COMM_WORLD
 comm_rank = comm.Get_rank()
@@ -7,144 +12,32 @@ comm_size = comm.Get_size()
 
 import h5py
 import numpy as np
-
-import virgo.mpi.util
 import virgo.mpi.parallel_hdf5 as phdf5
 import virgo.mpi.parallel_sort as psort
 
-def read_snapshot(snapshot_file, snap_nr, particle_ids):
+def check_tracing_orphan_subgroups(basedir, hbt_nr, snap_nr, snapshot_file):
     """
-    Read particle properties for the specified particle IDs.
-    Returns a dict of arrays.
-    """
+    This function checks if the internally assigned host FOF of orphaned 
+    subhaloes is done correctly. 
 
-    # Datasets to pass through from the snapshot
-    passthrough_datasets = ("FOFGroupIDs",)
-    
-    # Sub in the snapshot number
-    from virgo.util.partial_formatter import PartialFormatter
-    formatter = PartialFormatter()
-    filenames = formatter.format(snapshot_file, snap_nr=snap_nr, file_nr=None)
+    Parameters
+    ----------
+    basedir : str    
+        Location of the HBT catalogues.
+    hbt_nr : int
+        Snapshot index to select the ids used for tracing. Their FOF hosts will
+        be used to determine the host of the orphans we are tracking.
+    snap_nr : int
+        Snapshot number to test. Not equal to hbt_nr if the catalogues have only
+        been created for a subset of snapshots.
+    snapshot_file : str
+        Path to the snapshots in the form SNAPSHOT_BASE_NAME_{snap_nr:04d}.{file_nr}.hdf5
 
-    # Determine what particle types we have in the snapshot
-    if comm_rank == 0:
-        ptypes = []
-        with h5py.File(filenames.format(file_nr=0), "r") as infile:
-            nr_types = int(infile["Header"].attrs["NumPartTypes"])
-            nr_parts = infile["Header"].attrs["NumPart_Total"]
-            nr_parts_hw = infile["Header"].attrs["NumPart_Total_HighWord"]
-            for i in range(nr_types):
-                if nr_parts[i] > 0 or nr_parts_hw[i] > 0:
-                    ptypes.append(i)
-    else:
-        ptypes = None
-    ptypes = comm.bcast(ptypes)
-
-    # Read the particle data from the snapshot
-    particle_data = {"Type" : -np.ones(particle_ids.shape, dtype=np.int32)}
-    mf = phdf5.MultiFile(filenames, file_nr_attr=("Header","NumFilesPerSnapshot"), comm=comm)
-    for ptype in ptypes:
-
-        if ptype == 6:
-            continue # skip neutrinos
-        
-        # Read the IDs of this particle type
-        if comm_rank == 0:
-            print(f"Reading snapshot particle IDs for type {ptype}")
-
-        snapshot_ids = mf.read(f"PartType{ptype}/ParticleIDs")
-
-        # For each subhalo particle ID, find matching index in the snapshot (if any)
-        ptr = psort.parallel_match(particle_ids, snapshot_ids, comm=comm)
-        matched = (ptr>=0)
-
-        # Loop over particle properties to pass through
-        for name in passthrough_datasets:
-
-            # Read this property from the snapshot
-            snapshot_data = mf.read(f"PartType{ptype}/{name}")
-
-            # Allocate output array, if we didn't already
-            if name not in particle_data:
-                shape = (len(particle_ids),)+snapshot_data.shape[1:]
-                dtype = snapshot_data.dtype
-                particle_data[name] = -np.ones(shape, dtype=dtype) # initialize to -1 = not found
-
-            # Look up the value for each subhalo particle
-            particle_data[name][matched,...] = psort.fetch_elements(snapshot_data, ptr[matched], comm=comm)
-        
-        # Also store the type of each matched particle
-        particle_data["Type"][matched] = ptype
-
-    # Should have matched all particles, except for merged black holes 
-    # assert np.all(particle_data["Type"] >= 0)
-        
-    return particle_data
-    
-
-def read_particles(filenames, nr_local_subhalos):
-    """
-    Read in the particle IDs belonging to the subhalos on this MPI
-    rank from the specified SubSnap files. Returns a single array with
-    the concatenated IDs from all local subhalos in the order they
-    appear in the SubSnap files.
-    """
-
-    # First determine how many subhalos are in each SubSnap file
-    if comm_rank == 0:
-        subhalos_per_file = []
-        nr_files = 1
-        file_nr = 0
-        while file_nr < nr_files:
-            with h5py.File(filenames.format(file_nr=file_nr), "r") as infile:
-                subhalos_per_file.append(infile["Subhalos"].shape[0])
-                nr_files = int(infile["NumberOfFiles"][...])
-            file_nr += 1
-    else:
-        subhalos_per_file = None
-        nr_files = None
-    nr_files = comm.bcast(nr_files)
-    subhalos_per_file = np.asarray(comm.bcast(subhalos_per_file), dtype=int)
-    first_subhalo_in_file = np.cumsum(subhalos_per_file) - subhalos_per_file
-    
-    # Determine offset to first subhalo this rank reads
-    first_local_subhalo = comm.scan(nr_local_subhalos) - nr_local_subhalos
-
-    # Loop over all files
-    particle_ids = []
-    for file_nr in range(nr_files):
-
-        # Find range of subhalos this rank read from this file
-        i1 = first_local_subhalo - first_subhalo_in_file[file_nr]
-        i2 = i1 + nr_local_subhalos
-        i1 = max(0, i1)
-        i2 = min(subhalos_per_file[file_nr], i2)
-
-        # Read subhalo particle IDs, if there are any in this file for this rank
-        if i2 > i1:
-            with h5py.File(filenames.format(file_nr=file_nr), "r") as infile:
-                particle_ids.append(infile["SubhaloParticles"][i1:i2])
-
-    if len(particle_ids) > 0:
-        # Combine arrays from different files
-        particle_ids = np.concatenate(particle_ids)
-        # Combine arrays from different subhalos
-        particle_ids = np.concatenate(particle_ids)        
-    else:
-        # Some ranks may have read zero files
-        particle_ids = None
-    particle_ids = virgo.mpi.util.replace_none_with_zero_size(particle_ids, comm=comm)
-    
-    return particle_ids
-
-def sort_hbt_output(basedir, hbt_nr, snap_nr, snapshot_file):
-
-    """
-    This reorganizes a set of HBT SubSnap files into a single file which
-    contains one HDF5 dataset for each subhalo property. Subhalos are written
-    in order of TrackId.
-
-    Particle IDs in groups can be optionally copied to the output.
+    Returns
+    -------
+    total_number_mistracks: int
+        Number of orphans whose internally assigned FOF disagrees with the one 
+        we just found.
     """
 
     # Read in the input subhalos
@@ -225,7 +118,7 @@ def sort_hbt_output(basedir, hbt_nr, snap_nr, snapshot_file):
         print()
         print(f"Reading particle information.")
     
-    particle_data = read_snapshot(snapshot_file, snap_nr + 1, particle_ids)
+    particle_data = read_snapshot(snapshot_file, snap_nr + 1, particle_ids, ("FOFGroupIDs",))
     
     if comm_rank == 0:
         print(f"Done reading particle information.")
@@ -246,10 +139,6 @@ def sort_hbt_output(basedir, hbt_nr, snap_nr, snapshot_file):
 
     # Handle hostless haloes
     fof_decisions[:,1][fof_decisions[:,1] == 2147483647] = -1
-
-    # mf = phdf5.MultiFile(filenames, file_nr_dataset="NumberOfFiles", comm=comm)
-    # subhalos = mf.read("Subhalos")
-    # print("Done loading")
 
     # Find total number of subhalos
     total_nr_subhalos = comm.allreduce(len(subhalos_after))
@@ -283,11 +172,13 @@ def sort_hbt_output(basedir, hbt_nr, snap_nr, snapshot_file):
     local_number_disagreements = np.sum((fofs != fof_decisions[:,1]))
 
     # Check across all ranks across
-    total_number_disagreements = comm.allreduce(local_number_disagreements)
+    total_number_mistracks = comm.allreduce(local_number_disagreements)
     total_number_checks = comm.allreduce(len(fof_decisions))
     
     if comm_rank == 0:
-        print(f"{total_number_disagreements} out of {total_number_checks} orphans disagree.")                
+        print(f"{total_number_mistracks} out of {total_number_checks} orphans disagree.")                
+
+    return total_number_mistracks
 
 if __name__ == "__main__":
 
@@ -301,4 +192,4 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    sort_hbt_output(**vars(args))
+    check_tracing_orphan_subgroups(**vars(args))

--- a/testing/check_tracing_particles_resolved_subgroups.py
+++ b/testing/check_tracing_particles_resolved_subgroups.py
@@ -1,191 +1,44 @@
 #!/bin/env python
-from tqdm import tqdm
+
+# Retrieve helper functions, without having to define an __init__.py 
+import sys
+sys.path.append('../toolbox')
+from helper_functions import score_function, read_particles, read_snapshot
+
 from mpi4py import MPI
 comm = MPI.COMM_WORLD
 comm_rank = comm.Get_rank()
 comm_size = comm.Get_size()
 
-import h5py
 import numpy as np
-
-import virgo.mpi.util
 import virgo.mpi.parallel_hdf5 as phdf5
 import virgo.mpi.parallel_sort as psort
 
-def read_snapshot(snapshot_file, snap_nr, particle_ids):
+def check_tracing_resolved_subgroups(basedir, hbt_nr, snap_nr, snapshot_file):
     """
-    Read particle properties for the specified particle IDs.
-    Returns a dict of arrays.
-    """
-
-    # Datasets to pass through from the snapshot
-    passthrough_datasets = ("FOFGroupIDs",)
-    
-    # Sub in the snapshot number
-    from virgo.util.partial_formatter import PartialFormatter
-    formatter = PartialFormatter()
-    filenames = formatter.format(snapshot_file, snap_nr=snap_nr, file_nr=None)
-
-    # Determine what particle types we have in the snapshot
-    if comm_rank == 0:
-        ptypes = []
-        with h5py.File(filenames.format(file_nr=0), "r") as infile:
-            nr_types = int(infile["Header"].attrs["NumPartTypes"])
-            nr_parts = infile["Header"].attrs["NumPart_Total"]
-            nr_parts_hw = infile["Header"].attrs["NumPart_Total_HighWord"]
-            for i in range(nr_types):
-                if nr_parts[i] > 0 or nr_parts_hw[i] > 0:
-                    ptypes.append(i)
-    else:
-        ptypes = None
-    ptypes = comm.bcast(ptypes)
-
-    # Read the particle data from the snapshot
-    particle_data = {"Type" : -np.ones(particle_ids.shape, dtype=np.int32)}
-    mf = phdf5.MultiFile(filenames, file_nr_attr=("Header","NumFilesPerSnapshot"), comm=comm)
-    for ptype in ptypes:
-        if ptype == 6:
-            continue # skip neutrinos
-        # Read the IDs of this particle type
-        if comm_rank == 0:
-            print(f"Reading snapshot particle IDs for type {ptype}")
-        snapshot_ids = mf.read(f"PartType{ptype}/ParticleIDs")
-        # For each subhalo particle ID, find matching index in the snapshot (if any)
-        ptr = psort.parallel_match(particle_ids, snapshot_ids, comm=comm)
-        matched = (ptr>=0)
-        # Loop over particle properties to pass through
-        for name in passthrough_datasets:
-            # Read this property from the snapshot
-            snapshot_data = mf.read(f"PartType{ptype}/{name}")
-            # Allocate output array, if we didn't already
-            if name not in particle_data:
-                shape = (len(particle_ids),)+snapshot_data.shape[1:]
-                dtype = snapshot_data.dtype
-                particle_data[name] = -np.ones(shape, dtype=dtype) # initialize to -1 = not found
-            # Look up the value for each subhalo particle
-            # if comm_rank == 0:
-                # print(f"Looking up particle type {ptype} property {name} from snapshot")
-            particle_data[name][matched,...] = psort.fetch_elements(snapshot_data, ptr[matched], comm=comm)
-        
-        # Also store the type of each matched particle
-        particle_data["Type"][matched] = ptype
-
-    # Should have matched all particles, except for merged black holes 
-    # assert np.all(particle_data["Type"] >= 0)
-        
-    return particle_data
-    
-
-def read_particles(filenames, nr_local_subhalos):
-    """
-    Read in the particle IDs belonging to the subhalos on this MPI
-    rank from the specified SubSnap files. Returns a single array with
-    the concatenated IDs from all local subhalos in the order they
-    appear in the SubSnap files.
-    """
-
-    # First determine how many subhalos are in each SubSnap file
-    if comm_rank == 0:
-        subhalos_per_file = []
-        nr_files = 1
-        file_nr = 0
-        while file_nr < nr_files:
-            with h5py.File(filenames.format(file_nr=file_nr), "r") as infile:
-                subhalos_per_file.append(infile["Subhalos"].shape[0])
-                nr_files = int(infile["NumberOfFiles"][...])
-            file_nr += 1
-    else:
-        subhalos_per_file = None
-        nr_files = None
-    nr_files = comm.bcast(nr_files)
-    subhalos_per_file = np.asarray(comm.bcast(subhalos_per_file), dtype=int)
-    first_subhalo_in_file = np.cumsum(subhalos_per_file) - subhalos_per_file
-    
-    # Determine offset to first subhalo this rank reads
-    first_local_subhalo = comm.scan(nr_local_subhalos) - nr_local_subhalos
-
-    # Loop over all files
-    particle_ids = []
-    for file_nr in range(nr_files):
-
-        # Find range of subhalos this rank read from this file
-        i1 = first_local_subhalo - first_subhalo_in_file[file_nr]
-        i2 = i1 + nr_local_subhalos
-        i1 = max(0, i1)
-        i2 = min(subhalos_per_file[file_nr], i2)
-
-        # Read subhalo particle IDs, if there are any in this file for this rank
-        if i2 > i1:
-            with h5py.File(filenames.format(file_nr=file_nr), "r") as infile:
-                particle_ids.append(infile["SubhaloParticles"][i1:i2])
-
-    if len(particle_ids) > 0:
-        # Combine arrays from different files
-        particle_ids = np.concatenate(particle_ids)
-        # Combine arrays from different subhalos
-        particle_ids = np.concatenate(particle_ids)        
-    else:
-        # Some ranks may have read zero files
-        particle_ids = None
-    particle_ids = virgo.mpi.util.replace_none_with_zero_size(particle_ids, comm=comm)
-    
-    return particle_ids
-
-def rank_weight(rank):
-    '''
-    Function used to weigh the contribution of each particle towards a host FOF
-    decision, based on its boundness ranking.
+    This function checks if the internally assigned host FOF of resolved 
+    subhaloes is done correctly. 
 
     Parameters
-    -----------
-    rank : np.ndarray
-        Boundness ranking of the particle, in the previous output..
+    ----------
+    basedir : str    
+        Location of the HBT catalogues.
+    hbt_nr : int
+        Snapshot index to select the ids used for tracing. Their FOF hosts will
+        be used to determine the host of the subgroup we are tracking.
+    snap_nr : int
+        Snapshot number to test. Not equal to hbt_nr if the catalogues have only
+        been created for a subset of snapshots.
+    snapshot_file : str
+        Path to the snapshots in the form SNAPSHOT_BASE_NAME_{snap_nr:04d}.{file_nr}.hdf5
 
     Returns
-    -----------
-    np.ndarray
-        The weight of the particle used to score candidates.
-    '''
-    return 1 / (1 + np.sqrt(rank))
-
-def score_function(fof_groups):
-    '''
-    Score each candidate FOF based on several particles. Return the host with the
-    highest score.
-
-    Parameters
-    -----------
-    fof_groups : np.ndarray
-        The FOF group membership of a series of particles, previously sorted
-        descending boundness ranking order.
-
-    Returns
-    -----------
-    int
-        The highest scoring FOF candidate.
-    '''
-    weights = rank_weight(np.arange(len(fof_groups)))
-    
-    unique_candidates = np.unique(fof_groups)
-    scores = {}
-    for cand in unique_candidates:
-        scores[cand] = np.sum(weights[fof_groups == cand])
-
-    temp = max(scores.values())
-    result = [key for key in scores if scores[key] == temp][0] 
-    if result == 2147483647: result =-1 
-    return result
-
-def sort_hbt_output(basedir, hbt_nr, snap_nr, snapshot_file):
-
+    -------
+    total_number_mistracks: int
+        Number of resolved subgroups whose internally assigned FOF disagrees 
+        with the one we just found.
     """
-    This reorganizes a set of HBT SubSnap files into a single file which
-    contains one HDF5 dataset for each subhalo property. Subhalos are written
-    in order of TrackId.
 
-    Particle IDs in groups can be optionally copied to the output.
-    """
-    
     # Read in the input subhalos
     if comm_rank == 0:
         print(f"Testing HBTplus tracing of resolved subgroups between snapshot index {hbt_nr} and {hbt_nr + 1}")
@@ -279,7 +132,7 @@ def sort_hbt_output(basedir, hbt_nr, snap_nr, snapshot_file):
         print()
         print(f"Reading particle information.")
     
-    particle_data = read_snapshot(snapshot_file, snap_nr + 1, particle_ids)
+    particle_data = read_snapshot(snapshot_file, snap_nr + 1, particle_ids,("FOFGroupIDs",))
     
     if comm_rank == 0:
         print(f"Done reading particle information.")
@@ -333,11 +186,13 @@ def sort_hbt_output(basedir, hbt_nr, snap_nr, snapshot_file):
     local_number_disagreements = np.sum((fofs != fof_decisions[:,1]))
 
     # Check across all ranks across
-    total_number_disagreements = comm.allreduce(local_number_disagreements)
+    total_number_mistracks = comm.allreduce(local_number_disagreements)
     total_number_checks = comm.allreduce(len(fof_decisions))
     
     if comm_rank == 0:
-        print(f"{total_number_disagreements} out of {total_number_checks} disagree.")
+        print(f"{total_number_mistracks} out of {total_number_checks} disagree.")
+
+    return total_number_mistracks
 
 if __name__ == "__main__":
 
@@ -351,4 +206,4 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    sort_hbt_output(**vars(args))
+    check_tracing_resolved_subgroups(**vars(args))

--- a/testing/test_tracing.sh
+++ b/testing/test_tracing.sh
@@ -2,19 +2,19 @@ module purge
 module load gnu_comp/11.1.0 openmpi/4.1.1 python/3.10.1
 
 # Example path for COLIBRE
-indir=/cosma7/data/dp004/dc-foro1/colibre/hbt_testing/removing_duplicates
-snap_files="/cosma7/data/dp004/dc-foro1/colibre/colibre_{snap_nr:04d}.hdf5";
+indir=/cosma8/data/dp004/dc-foro1/hbt_runs/groups_COLIBRE_L25N188
+snap_files="/cosma8/data/dp004/dc-foro1/colibre/low_res_test/colibre_{snap_nr:04d}.hdf5";
 
-# Example path for FLAMINGO 
-indir=/cosma8/data/dp004/dc-foro1/hbt_runs/groups_FLAMINGO_L1000N0900
-snap_files="/cosma8/data/dp004/jlvc76/FLAMINGO/FOF/L1000N0900/HYDRO_FIDUCIAL/fof_snapshot/flamingo_{snap_nr:04d}.hdf5";
+# Example path for FLAMINGO
+# indir=/cosma8/data/dp004/dc-foro1/hbt_runs/groups_FLAMINGO_L1000N0900
+# snap_files="/cosma8/data/dp004/jlvc76/FLAMINGO/FOF/L1000N0900/HYDRO_FIDUCIAL/fof_snapshot/flamingo_{snap_nr:04d}.hdf5";
 
-mpirun -np 32 python3 -m mpi4py ./check_interhost_subhalos.py "${indir}" 76 76 --snapshot-file="${snap_files}";
+mpirun -np 32 python3 -m mpi4py ./check_interhost_subhalos.py "${indir}" 126 126 --snapshot-file="${snap_files}";
 echo
-mpirun -np 32 python3 -m mpi4py ./check_presence_duplicate_particles.py "${indir}" 76;
+mpirun -np 32 python3 -m mpi4py ./check_presence_duplicate_particles.py "${indir}" 126;
 echo
-mpirun -np 32 python3 -m mpi4py ./check_consistency_particles_orphan_subgroups.py "${indir}" 76 76 --snapshot-file="${snap_files}";
+mpirun -np 32 python3 -m mpi4py ./check_consistency_particles_orphan_subgroups.py "${indir}" 126;
 echo 
-mpirun -np 32 python3 -m mpi4py ./check_tracing_particles_orphan_subgroups.py "${indir}" 76 76 --snapshot-file="${snap_files}";
+mpirun -np 32 python3 -m mpi4py ./check_tracing_particles_orphan_subgroups.py "${indir}" 126 126 --snapshot-file="${snap_files}";
 echo 
-mpirun -np 32 python3 -m mpi4py ./check_tracing_particles_resolved_subgroups.py "${indir}" 76 76 --snapshot-file="${snap_files}";
+mpirun -np 32 python3 -m mpi4py ./check_tracing_particles_resolved_subgroups.py "${indir}" 126 126 --snapshot-file="${snap_files}";

--- a/testing/test_tracing.sh
+++ b/testing/test_tracing.sh
@@ -1,11 +1,16 @@
 module purge
 module load gnu_comp/11.1.0 openmpi/4.1.1 python/3.10.1
 
-# Example path for FLAMINGO
+# Example path for COLIBRE 
+indir=/cosma7/data/dp004/dc-foro1/colibre/hbt_testing/removing_duplicates_no_mergers
+snap_files="/cosma7/data/dp004/dc-foro1/colibre/colibre_{snap_nr:04d}.hdf5";
+
+# Example path for FLAMINGO 
 indir=/cosma8/data/dp004/dc-foro1/hbt_runs/groups_FLAMINGO_L1000N0900
 snap_files="/cosma8/data/dp004/jlvc76/FLAMINGO/FOF/L1000N0900/HYDRO_FIDUCIAL/fof_snapshot/flamingo_{snap_nr:04d}.hdf5";
 
-echo 
+mpirun -np 32 python3 -m mpi4py ./check_presence_duplicate_particles.py "${indir}" $i;
+echo
 mpirun -np 32 python3 -m mpi4py ./check_consistency_particles_orphan_subgroups.py "${indir}" 76 76 --snapshot-file="${snap_files}";
 echo 
 mpirun -np 32 python3 -m mpi4py ./check_tracing_particles_orphan_subgroups.py "${indir}" 76 76 --snapshot-file="${snap_files}";

--- a/testing/test_tracing.sh
+++ b/testing/test_tracing.sh
@@ -1,15 +1,17 @@
 module purge
 module load gnu_comp/11.1.0 openmpi/4.1.1 python/3.10.1
 
-# Example path for COLIBRE 
-indir=/cosma7/data/dp004/dc-foro1/colibre/hbt_testing/removing_duplicates_no_mergers
+# Example path for COLIBRE
+indir=/cosma7/data/dp004/dc-foro1/colibre/hbt_testing/removing_duplicates
 snap_files="/cosma7/data/dp004/dc-foro1/colibre/colibre_{snap_nr:04d}.hdf5";
 
 # Example path for FLAMINGO 
 indir=/cosma8/data/dp004/dc-foro1/hbt_runs/groups_FLAMINGO_L1000N0900
 snap_files="/cosma8/data/dp004/jlvc76/FLAMINGO/FOF/L1000N0900/HYDRO_FIDUCIAL/fof_snapshot/flamingo_{snap_nr:04d}.hdf5";
 
-mpirun -np 32 python3 -m mpi4py ./check_presence_duplicate_particles.py "${indir}" $i;
+mpirun -np 32 python3 -m mpi4py ./check_interhost_subhalos.py "${indir}" 76 76 --snapshot-file="${snap_files}";
+echo
+mpirun -np 32 python3 -m mpi4py ./check_presence_duplicate_particles.py "${indir}" 76;
 echo
 mpirun -np 32 python3 -m mpi4py ./check_consistency_particles_orphan_subgroups.py "${indir}" 76 76 --snapshot-file="${snap_files}";
 echo 

--- a/toolbox/helper_functions.py
+++ b/toolbox/helper_functions.py
@@ -9,6 +9,88 @@ import h5py
 import numpy as np
 
 import virgo.mpi.util
+import virgo.mpi.parallel_hdf5 as phdf5
+import virgo.mpi.parallel_sort as psort
+
+def read_snapshot(snapshot_file, snap_nr, particle_ids, datasets_to_load):
+    """
+    Reads the requested snapshot properties for the specified particle IDs as a 
+    dict of arrays.
+
+    Parameters
+    ----------
+    snapshot_file : f-string
+        Path to the snapshots in the form SNAPSHOT_BASE_NAME_{snap_nr:04d}.{file_nr}.hdf5
+    snap_nr : int
+        Snapshot number to read
+    particle_ids : np.array
+        Ids of the particles whose properties we want to load
+    datasets_to_load : tuple
+        Name of the datasets to load for each particle.
+
+    Returns
+    -------
+    dict of arrays
+        Dictionary with each key corresponding to an array containing the 
+        requested particle property, sorted in the same order as the input
+        particle ids.
+    """
+
+    # Substitute in the snapshot number
+    from virgo.util.partial_formatter import PartialFormatter
+    formatter = PartialFormatter()
+    filenames = formatter.format(snapshot_file, snap_nr=snap_nr, file_nr=None)
+
+    # Determine what particle types we have in the snapshot
+    if comm_rank == 0:
+        ptypes = []
+        with h5py.File(filenames.format(file_nr=0), "r") as infile:
+            nr_types = int(infile["Header"].attrs["NumPartTypes"])
+            nr_parts = infile["Header"].attrs["NumPart_Total"]
+            nr_parts_hw = infile["Header"].attrs["NumPart_Total_HighWord"]
+            for i in range(nr_types):
+                if nr_parts[i] > 0 or nr_parts_hw[i] > 0:
+                    ptypes.append(i)
+    else:
+        ptypes = None
+    ptypes = comm.bcast(ptypes)
+
+    # Read the particle data from the snapshot
+    particle_data = {"Type" : -np.ones(particle_ids.shape, dtype=np.int32)}
+    mf = phdf5.MultiFile(filenames, file_nr_attr=("Header","NumFilesPerSnapshot"), comm=comm)
+    for ptype in ptypes:
+        
+        # Skip neutrinos
+        if ptype == 6: continue
+              
+        # Read the IDs of this particle type
+        if comm_rank == 0:
+            print(f"Reading snapshot particle IDs for type {ptype}")
+        snapshot_ids = mf.read(f"PartType{ptype}/ParticleIDs")
+
+        # For each subhalo particle ID, find matching index in the snapshot (if any)
+        ptr = psort.parallel_match(particle_ids, snapshot_ids, comm=comm)
+        matched = (ptr>=0)
+
+        # Loop over particle properties to pass through
+        for name in datasets_to_load:
+
+            # Read this property from the snapshot
+            snapshot_data = mf.read(f"PartType{ptype}/{name}")
+
+            # Allocate output array, if we didn't already
+            if name not in particle_data:
+                shape = (len(particle_ids),)+snapshot_data.shape[1:]
+                dtype = snapshot_data.dtype
+                particle_data[name] = -np.ones(shape, dtype=dtype) # initialize to -1 = not found
+
+            # Look up the value for each subhalo particle
+            particle_data[name][matched,...] = psort.fetch_elements(snapshot_data, ptr[matched], comm=comm)
+        
+        # Also store the type of each matched particle
+        particle_data["Type"][matched] = ptype
+
+    return particle_data
 
 def read_particles(filenames, nr_local_subhalos):
     """
@@ -16,6 +98,18 @@ def read_particles(filenames, nr_local_subhalos):
     rank from the specified SubSnap files. Returns a single array with
     the concatenated IDs from all local subhalos in the order they
     appear in the SubSnap files.
+
+    Parameters
+    ----------
+    filenames : f-string
+        Location of the catalogue files to read
+    nr_local_subhaloes : int
+        Number of subhaloes to be read.
+    
+    Returns
+    -------
+    particle_ids : np.ndarray
+        Concatenated particle Ids bound to each local subhalo. 
     """
 
     # First determine how many subhalos are in each SubSnap file
@@ -65,3 +159,80 @@ def read_particles(filenames, nr_local_subhalos):
     
     return particle_ids
 
+def read_source_particles(filenames, nr_local_subhalos, nr_files):
+    """
+    Reads in the particle IDs that are part of the source of the subhalos 
+    present in this MPI rank, from the specified SrcSnap files. Returns a single
+    array with the concatenated IDs from all local subhalos in the order they
+    appear in the SubSnap files.
+
+    Parameters
+    ----------
+    filenames : f-string
+        Location of the source files to read
+    nr_local_subhaloes : int
+        Number of subhaloes to be read.
+    nr_files : int
+        Number of files per HBT output.
+    
+    Returns
+    -------
+    particle_ids : np.ndarray
+        Concatenated particle Ids associated to the source of each local subhalo. 
+    Nsource : np.ndarray
+        Number of source particles associated to each local subhalo. 
+    """
+
+    # First determine how many subhalos are in each SubSnap file
+    if comm_rank == 0:
+        subhalos_per_file = []
+        file_nr = 0
+        while file_nr < nr_files:
+            with h5py.File(filenames.format(file_nr=file_nr), "r") as infile:
+                subhalos_per_file.append(infile["SrchaloParticles"].shape[0])
+            file_nr += 1
+    else:
+        subhalos_per_file = None
+        nr_files = None
+    
+    nr_files = comm.bcast(nr_files)
+    subhalos_per_file = np.asarray(comm.bcast(subhalos_per_file), dtype=int)
+    first_subhalo_in_file = np.cumsum(subhalos_per_file) - subhalos_per_file
+
+    # Determine offset to first subhalo this rank reads
+    first_local_subhalo = comm.scan(nr_local_subhalos) - nr_local_subhalos
+
+    # Loop over all files
+    particle_ids = []
+    for file_nr in range(nr_files):
+
+        # Find range of subhalos this rank read from this file
+        i1 = first_local_subhalo - first_subhalo_in_file[file_nr]
+        i2 = i1 + nr_local_subhalos
+        i1 = max(0, i1)
+        i2 = min(subhalos_per_file[file_nr], i2)
+
+        # Read subhalo particle IDs, if there are any in this file for this rank
+        if i2 > i1:
+            with h5py.File(filenames.format(file_nr=file_nr), "r") as infile:
+                particle_ids.append(infile["SrchaloParticles"][i1:i2])
+
+    # Need to compute number of source particles, since it is not present in the
+    # normal catalogue outputs.
+    Nsource = np.zeros(len(particle_ids[0]), int)
+    for i in range(len(particle_ids[0])):
+        Nsource[i] = len(particle_ids[0][i])
+
+    if len(particle_ids) > 0:
+        # Combine arrays from different files
+        particle_ids = np.concatenate(particle_ids)
+        # Combine arrays from different subhalos
+        particle_ids = np.concatenate(particle_ids)        
+    else:
+        # Some ranks may have read zero files
+        particle_ids = None
+    
+    particle_ids = virgo.mpi.util.replace_none_with_zero_size(particle_ids, comm=comm)
+    
+    # Need to return track ids, since the catalogues do not know Nsource
+    return particle_ids, Nsource

--- a/toolbox/helper_functions.py
+++ b/toolbox/helper_functions.py
@@ -1,0 +1,67 @@
+#!/bin/env python
+from tqdm import tqdm
+from mpi4py import MPI
+comm = MPI.COMM_WORLD
+comm_rank = comm.Get_rank()
+comm_size = comm.Get_size()
+
+import h5py
+import numpy as np
+
+import virgo.mpi.util
+
+def read_particles(filenames, nr_local_subhalos):
+    """
+    Read in the particle IDs belonging to the subhalos on this MPI
+    rank from the specified SubSnap files. Returns a single array with
+    the concatenated IDs from all local subhalos in the order they
+    appear in the SubSnap files.
+    """
+
+    # First determine how many subhalos are in each SubSnap file
+    if comm_rank == 0:
+        subhalos_per_file = []
+        nr_files = 1
+        file_nr = 0
+        while file_nr < nr_files:
+            with h5py.File(filenames.format(file_nr=file_nr), "r") as infile:
+                subhalos_per_file.append(infile["Subhalos"].shape[0])
+                nr_files = int(infile["NumberOfFiles"][...])
+            file_nr += 1
+    else:
+        subhalos_per_file = None
+        nr_files = None
+    nr_files = comm.bcast(nr_files)
+    subhalos_per_file = np.asarray(comm.bcast(subhalos_per_file), dtype=int)
+    first_subhalo_in_file = np.cumsum(subhalos_per_file) - subhalos_per_file
+    
+    # Determine offset to first subhalo this rank reads
+    first_local_subhalo = comm.scan(nr_local_subhalos) - nr_local_subhalos
+
+    # Loop over all files
+    particle_ids = []
+    for file_nr in range(nr_files):
+
+        # Find range of subhalos this rank read from this file
+        i1 = first_local_subhalo - first_subhalo_in_file[file_nr]
+        i2 = i1 + nr_local_subhalos
+        i1 = max(0, i1)
+        i2 = min(subhalos_per_file[file_nr], i2)
+
+        # Read subhalo particle IDs, if there are any in this file for this rank
+        if i2 > i1:
+            with h5py.File(filenames.format(file_nr=file_nr), "r") as infile:
+                particle_ids.append(infile["SubhaloParticles"][i1:i2])
+
+    if len(particle_ids) > 0:
+        # Combine arrays from different files
+        particle_ids = np.concatenate(particle_ids)
+        # Combine arrays from different subhalos
+        particle_ids = np.concatenate(particle_ids)        
+    else:
+        # Some ranks may have read zero files
+        particle_ids = None
+    particle_ids = virgo.mpi.util.replace_none_with_zero_size(particle_ids, comm=comm)
+    
+    return particle_ids
+


### PR DESCRIPTION
This branch makes it so that subhaloes are constrained to the FOF they were assigned to, based on their most bound tracer particles. Particles associated to a subhalo that are hostless still retain the association. This change prevents duplication of particles across FOF groups, but some cases remain, to be dealt with in a separate pull request. 

The changes involve loading the FOF host id in LoadSnapshot, to update the value of HostId for the particles within Subhalo Particle vectors. We can likely save some I/O time since we are reading the same properties twice (including coordinates, velocities, etc).

 
