### PR TITLE
Distribute particles between MPI ranks using hash of particle ID

### DIFF
--- a/src/hash_integers.h
+++ b/src/hash_integers.h
@@ -24,3 +24,11 @@ inline HBTInt HashInteger(HBTInt x) {
 #endif
   return y;
 }
+
+
+/*
+  Function to assign particle ID to an MPI rank based on hashing the ID
+*/
+inline int RankFromIdHash(HBTInt Id, int comm_size) {
+  return std::abs(HashInteger(Id)) % comm_size;
+}

--- a/src/hash_integers.h
+++ b/src/hash_integers.h
@@ -26,10 +26,10 @@ inline HBTInt HashInteger(HBTInt x)
   return y;
 }
 
-
 /*
   Function to assign particle ID to an MPI rank based on hashing the ID
 */
-inline int RankFromIdHash(HBTInt Id, int comm_size) {
+inline int RankFromIdHash(HBTInt Id, int comm_size)
+{
   return std::abs(HashInteger(Id)) % comm_size;
 }

--- a/src/particle_exchanger.h
+++ b/src/particle_exchanger.h
@@ -198,8 +198,12 @@ void ParticleExchanger_t<Halo_T>::QueryParticles()
   snap.GetIndices(RoamParticles);
   for (auto &&p : RoamParticles)
   {
-    if (p.Id != SpecialConst::NullParticleId)
+    if (p.Id != SpecialConst::NullParticleId) {
       p = snap.Particles[p.Id]; // query the particle property; may need to spawn particles due to star formation here.
+    } else {
+      /* Not found, so it must NOT be a DM or star particle because they can't disappear */
+      assert((p.Type != TypeDM) && (p.Type != TypeStar));
+    }
   }
 
   ParticleExchangeComp::RestoreParticleOrder(RoamParticles);

--- a/src/particle_exchanger.h
+++ b/src/particle_exchanger.h
@@ -201,8 +201,13 @@ void ParticleExchanger_t<Halo_T>::QueryParticles()
     if (p.Id != SpecialConst::NullParticleId) {
       p = snap.Particles[p.Id]; // query the particle property; may need to spawn particles due to star formation here.
     } else {
-      /* Not found, so it must NOT be a DM or star particle because they can't disappear */
+#ifdef DM_ONLY
+      /* All DM particles should be found */
+      assert(false); // Assume p.Type=TypeDM since type is not stored explicitly
+#else
+      /* In hydro runs DM and star particles are not expected to disappear */
       assert((p.Type != TypeDM) && (p.Type != TypeStar));
+#endif
     }
   }
 

--- a/src/particle_exchanger.h
+++ b/src/particle_exchanger.h
@@ -14,6 +14,7 @@
 #include "mymath.h"
 #include "snapshot.h"
 #include "subhalo.h"
+#include "sort_by_hash.h"
 
 class OrderedParticle_t : public Particle_t
 {
@@ -154,28 +155,20 @@ void ParticleExchanger_t<Halo_T>::CollectParticles()
 
 template <class Halo_T>
 void ParticleExchanger_t<Halo_T>::SendParticles()
-{ // order the particles and send them to the corresponding processing according to ProcessIdRange
-  sort(LocalParticles.begin(), LocalParticles.end(), ParticleExchangeComp::CompParticleId);
+{
+
+  // Sort the particles by destination rank
+  std::vector<HBTInt> offset = sort_by_hash(LocalParticles, world.size());
 
   LocalSizes.resize(world.size());
   LocalIterators.resize(world.size());
-  int rank = 0;
-  for (auto it = LocalParticles.begin(); it != LocalParticles.end(); ++it)
-  {
-    while (it->Id >= snap.ProcessIdRanges[rank])
-    {
-      if (rank == world.size()) // no particle id should exceed ProcessIdRange.back()
-      {
-        cerr << "Error: invalid particle id: " << it->Id << endl;
-        exit(1);
-      }
-      LocalIterators[rank++] = it;
-    }
+  int rank;
+  for(rank=0; rank<world.size(); rank++) {
+    LocalIterators[rank] = LocalParticles.begin() + offset[rank];
   }
-  while (rank < world.size())
-    LocalIterators[rank++] = LocalParticles.end();
-  for (rank = 0; rank < world.size() - 1; rank++)
+  for (rank = 0; rank < world.size() - 1; rank++) {
     LocalSizes[rank] = LocalIterators[rank + 1] - LocalIterators[rank];
+  }
   LocalSizes[rank] = LocalParticles.end() - LocalIterators.back();
 
   RoamSizes.resize(world.size());

--- a/src/particle_exchanger.h
+++ b/src/particle_exchanger.h
@@ -170,7 +170,7 @@ void ParticleExchanger_t<Halo_T>::SendParticles()
   {
     LocalSizes[rank] = LocalIterators[rank + 1] - LocalIterators[rank];
   }
-  LocalSizes[world.size()-1] = LocalParticles.end() - LocalIterators.back();
+  LocalSizes[world.size() - 1] = LocalParticles.end() - LocalIterators.back();
 
   RoamSizes.resize(world.size());
   MPI_Alltoall(LocalSizes.data(), 1, MPI_HBT_INT, RoamSizes.data(), 1, MPI_HBT_INT, world.Communicator);
@@ -213,7 +213,7 @@ void ParticleExchanger_t<Halo_T>::QueryParticles()
 #else
       /* In hydro runs particles are allowed to disappear if either we don't
          know their type or we know they're not a tracer type. */
-      assert((p.Type==TypeMax) || (!p.IsTracer()));
+      assert((p.Type == TypeMax) || (!p.IsTracer()));
 #endif
     }
   }

--- a/src/particle_exchanger.h
+++ b/src/particle_exchanger.h
@@ -162,16 +162,15 @@ void ParticleExchanger_t<Halo_T>::SendParticles()
 
   LocalSizes.resize(world.size());
   LocalIterators.resize(world.size());
-  int rank;
-  for (rank = 0; rank < world.size(); rank++)
+  for (int rank = 0; rank < world.size(); rank++)
   {
     LocalIterators[rank] = LocalParticles.begin() + offset[rank];
   }
-  for (rank = 0; rank < world.size() - 1; rank++)
+  for (int rank = 0; rank < world.size() - 1; rank++)
   {
     LocalSizes[rank] = LocalIterators[rank + 1] - LocalIterators[rank];
   }
-  LocalSizes[rank] = LocalParticles.end() - LocalIterators.back();
+  LocalSizes[world.size()-1] = LocalParticles.end() - LocalIterators.back();
 
   RoamSizes.resize(world.size());
   MPI_Alltoall(LocalSizes.data(), 1, MPI_HBT_INT, RoamSizes.data(), 1, MPI_HBT_INT, world.Communicator);

--- a/src/particle_exchanger.h
+++ b/src/particle_exchanger.h
@@ -163,10 +163,12 @@ void ParticleExchanger_t<Halo_T>::SendParticles()
   LocalSizes.resize(world.size());
   LocalIterators.resize(world.size());
   int rank;
-  for(rank=0; rank<world.size(); rank++) {
+  for (rank = 0; rank < world.size(); rank++)
+  {
     LocalIterators[rank] = LocalParticles.begin() + offset[rank];
   }
-  for (rank = 0; rank < world.size() - 1; rank++) {
+  for (rank = 0; rank < world.size() - 1; rank++)
+  {
     LocalSizes[rank] = LocalIterators[rank + 1] - LocalIterators[rank];
   }
   LocalSizes[rank] = LocalParticles.end() - LocalIterators.back();
@@ -198,9 +200,12 @@ void ParticleExchanger_t<Halo_T>::QueryParticles()
   snap.GetIndices(RoamParticles);
   for (auto &&p : RoamParticles)
   {
-    if (p.Id != SpecialConst::NullParticleId) {
+    if (p.Id != SpecialConst::NullParticleId)
+    {
       p = snap.Particles[p.Id]; // query the particle property; may need to spawn particles due to star formation here.
-    } else {
+    }
+    else
+    {
 #ifdef DM_ONLY
       /* All DM particles should be found */
       assert(false); // Assume p.Type=TypeDM since type is not stored explicitly

--- a/src/particle_exchanger.h
+++ b/src/particle_exchanger.h
@@ -206,9 +206,9 @@ void ParticleExchanger_t<Halo_T>::QueryParticles()
       assert(false); // Assume p.Type=TypeDM since type is not stored explicitly
 #else
       /* In hydro runs DM and star particles are not expected to disappear.
-         Type=TypeMax indicates that the type associated with the particle ID
-         is not known so we can't do the consistency check. */
-      assert((p.Type != TypeDM) && (p.Type != TypeStar));
+         Type=TypeMax indicates that we're searching for tracers, in which
+         case we don't know the type but we do expect all tracers to exist. */
+      assert((p.Type != TypeDM) && (p.Type != TypeStar) && (p.Type != TypeMax));
 #endif
     }
   }

--- a/src/particle_exchanger.h
+++ b/src/particle_exchanger.h
@@ -205,7 +205,9 @@ void ParticleExchanger_t<Halo_T>::QueryParticles()
       /* All DM particles should be found */
       assert(false); // Assume p.Type=TypeDM since type is not stored explicitly
 #else
-      /* In hydro runs DM and star particles are not expected to disappear */
+      /* In hydro runs DM and star particles are not expected to disappear.
+         Type=TypeMax indicates that the type associated with the particle ID
+         is not known so we can't do the consistency check. */
       assert((p.Type != TypeDM) && (p.Type != TypeStar));
 #endif
     }

--- a/src/particle_exchanger.h
+++ b/src/particle_exchanger.h
@@ -206,13 +206,14 @@ void ParticleExchanger_t<Halo_T>::QueryParticles()
     else
     {
 #ifdef DM_ONLY
-      /* All DM particles should be found */
-      assert(false); // Assume p.Type=TypeDM since type is not stored explicitly
+      /* Currently IsTracer() is always true for DM only runs so this will
+         abort if any DM particle is not found. Would need to change this
+         for annihilating DM, for example. */
+      assert(!p.IsTracer());
 #else
-      /* In hydro runs DM and star particles are not expected to disappear.
-         Type=TypeMax indicates that we're searching for tracers, in which
-         case we don't know the type but we do expect all tracers to exist. */
-      assert((p.Type != TypeDM) && (p.Type != TypeStar) && (p.Type != TypeMax));
+      /* In hydro runs particles are allowed to disappear if either we don't
+         know their type or we know they're not a tracer type. */
+      assert((p.Type==TypeMax) || (!p.IsTracer()));
 #endif
     }
   }

--- a/src/snapshot.h
+++ b/src/snapshot.h
@@ -177,7 +177,7 @@ class ParticleSnapshot_t : public Snapshot_t
   IndexTable_t<HBTInt, HBTInt> *ParticleHash;
 
   void ExchangeParticles(MpiWorker_t &world);
-  void PartitionParticles(MpiWorker_t &world, vector<HBTInt> &offset);
+  vector<HBTInt> PartitionParticles(MpiWorker_t &world);
 
 public:
   vector<Particle_t> Particles;

--- a/src/snapshot.h
+++ b/src/snapshot.h
@@ -177,14 +177,11 @@ class ParticleSnapshot_t : public Snapshot_t
   IndexTable_t<HBTInt, HBTInt> *ParticleHash;
 
   void ExchangeParticles(MpiWorker_t &world);
-  void PartitionParticles(MpiWorker_t &world, vector<int> &offset);
-  bool IsContiguousId(MpiWorker_t &world, HBTInt &GlobalIdMin);
-  HBTInt IdMin, IdMax;
+  void PartitionParticles(MpiWorker_t &world, vector<HBTInt> &offset);
 
 public:
   vector<Particle_t> Particles;
   HBTInt NumberOfParticlesOnAllNodes;
-  vector<HBTInt> ProcessIdRanges; // IdRange on each processor is [ProcessIdRanges[i], ProcessIdRanges[i+1]).
 
   ParticleSnapshot_t()
     : Snapshot_t(), Particles(), ParticleHash(), MappedHash(), FlatHash(), NumberOfParticlesOnAllNodes(0)

--- a/src/snapshot_exchanger.cpp
+++ b/src/snapshot_exchanger.cpp
@@ -67,6 +67,20 @@ void ParticleSnapshot_t::ExchangeParticles(MpiWorker_t &world)
   vector<Particle_t> ReceivedParticles;
   ReceivedParticles.resize(CompileOffsets(ReceiveSizes, ReceiveOffsets));
 
+#ifndef NDEBUG
+  // Bounds check offsets and counts in debug mode
+  for(int rank=0; rank<world.size(); rank+=1) {
+    if(SendSizes[rank] > 0) {
+      assert(SendOffsets[rank] >= 0);
+      assert(SendOffsets[rank] + SendSizes[rank] <= Particles.size());
+    }
+    if(ReceiveSizes[rank] > 0) {
+      assert(ReceiveOffsets[rank] >= 0);
+      assert(ReceiveOffsets[rank] + ReceiveSizes[rank] <= ReceivedParticles.size());
+    }
+  }
+#endif
+  
   MPI_Datatype MPI_HBT_Particle;
   Particle_t().create_MPI_type(MPI_HBT_Particle);
 

--- a/src/snapshot_exchanger.cpp
+++ b/src/snapshot_exchanger.cpp
@@ -69,18 +69,21 @@ void ParticleSnapshot_t::ExchangeParticles(MpiWorker_t &world)
 
 #ifndef NDEBUG
   // Bounds check offsets and counts in debug mode
-  for(int rank=0; rank<world.size(); rank+=1) {
-    if(SendSizes[rank] > 0) {
+  for (int rank = 0; rank < world.size(); rank += 1)
+  {
+    if (SendSizes[rank] > 0)
+    {
       assert(SendOffsets[rank] >= 0);
       assert(SendOffsets[rank] + SendSizes[rank] <= Particles.size());
     }
-    if(ReceiveSizes[rank] > 0) {
+    if (ReceiveSizes[rank] > 0)
+    {
       assert(ReceiveOffsets[rank] >= 0);
       assert(ReceiveOffsets[rank] + ReceiveSizes[rank] <= ReceivedParticles.size());
     }
   }
 #endif
-  
+
   MPI_Datatype MPI_HBT_Particle;
   Particle_t().create_MPI_type(MPI_HBT_Particle);
 

--- a/src/snapshot_exchanger.cpp
+++ b/src/snapshot_exchanger.cpp
@@ -13,6 +13,7 @@ using namespace std;
 #include "mymath.h"
 #include "pairwise_alltoallv.h"
 #include "snapshot.h"
+#include "sort_by_hash.h"
 
 inline int GetGrid(HBTReal x, HBTReal step, int dim)
 {
@@ -30,129 +31,23 @@ inline int AssignCell(HBTxyz &Pos, const HBTReal step[3], const vector<int> &dim
   return GRIDtoRank(GID(0), GID(1), GID(2));
 }
 
-void ParallelStride(MpiWorker_t &world, vector<Particle_t> &Particles, HBTInt &offset, HBTInt steps)
+void ParticleSnapshot_t::PartitionParticles(MpiWorker_t &world, vector<HBTInt> &offset)
 {
-  while (steps)
-  {
-    HBTInt nmax = Particles.size() - offset;
-    MPI_Comm newcomm;
-    MPI_Comm_split(world.Communicator, nmax == 0, 0, &newcomm);
-    int newcomm_size;
-    MPI_Comm_size(newcomm, &newcomm_size);
-
-    HBTInt n = 0;
-    if (nmax)
-    {
-      n = steps / newcomm_size;
-      if (n * newcomm_size < steps)
-        n++;
-      if (n > nmax)
-        n = nmax;
-
-      HBTInt pid = Particles[offset + n - 1].Id;
-      HBTInt MinId;
-      MPI_Allreduce(&pid, &MinId, 1, MPI_HBT_INT, MPI_MIN, newcomm);
-
-      if (pid > MinId) // fastforward sparse ranks
-      {
-        n = offset;
-        while (Particles[offset].Id < MinId)
-          offset++;
-        n = offset - n;
-      }
-      else
-        offset += n;
-    }
-
-    MPI_Comm_free(&newcomm);
-
-    MPI_Allreduce(MPI_IN_PLACE, &n, 1, MPI_HBT_INT, MPI_SUM, world.Communicator);
-    steps -= n;
-  }
-}
-bool ParticleSnapshot_t::IsContiguousId(MpiWorker_t &world, HBTInt &GlobalIdMin)
-{
-  MPI_Comm newcomm;
-  MPI_Comm_split(world.Communicator, Particles.size() == 0, 0, &newcomm);
-  int newcomm_size, newrank;
-  MPI_Comm_size(newcomm, &newcomm_size);
-  MPI_Comm_rank(newcomm, &newrank);
-
-  int flag_contig = 0;
-  if (Particles.size())
-  {
-    IdMin = Particles.front().Id;
-    IdMax = Particles.back().Id;
-    const int root = 0;
-    if (newrank == root)
-    {
-      MPI_Reduce(MPI_IN_PLACE, &IdMin, 1, MPI_HBT_INT, MPI_MIN, root, newcomm);
-      MPI_Reduce(MPI_IN_PLACE, &IdMax, 1, MPI_HBT_INT, MPI_MAX, root, newcomm);
-      flag_contig = (IdMax - IdMin + 1 == NumberOfParticlesOnAllNodes);
-      if (flag_contig)
-        cout << "Contiguous particle Ids." << endl;
-    }
-    else
-    {
-      MPI_Reduce(&IdMin, &IdMin, 1, MPI_HBT_INT, MPI_MIN, root, newcomm);
-      MPI_Reduce(&IdMax, &IdMax, 1, MPI_HBT_INT, MPI_MAX, root, newcomm);
-      IdMin = 0;
-    }
-  }
-  else
-    IdMin = 0;
-
-  MPI_Comm_free(&newcomm);
-  MPI_Allreduce(MPI_IN_PLACE, &flag_contig, 1, MPI_INT, MPI_LOR, world.Communicator);
-  MPI_Allreduce(&IdMin, &GlobalIdMin, 1, MPI_HBT_INT, MPI_BOR, world.Communicator);
-
-  return flag_contig;
+  offset = sort_by_hash(Particles, world.size());
 }
 
-void ParticleSnapshot_t::PartitionParticles(MpiWorker_t &world, vector<int> &offset)
-{
-  int nremainder = (((HBTInt)NumberOfParticlesOnAllNodes) % ((HBTInt)world.size()));
-  HBTInt nnew = NumberOfParticlesOnAllNodes / world.size() + 1;
-
-  HBTInt GlobalIdMin;
-  if (IsContiguousId(world, GlobalIdMin))
-  {
-    HBTInt &upperbound = GlobalIdMin;
-    int rank = 0, pid = 0;
-    while (pid < Particles.size())
-    {
-      if (Particles[pid].Id < upperbound)
-        pid++;
-      else
-      {
-        offset[rank] = pid;
-        if (rank == nremainder)
-          nnew--;
-        rank++;
-        upperbound += nnew;
-      }
-    }
-    while (rank < world.size())
-      offset[rank++] = pid;
-    assert(pid == Particles.size());
-  }
-  else
-  {
-    HBTInt this_offset = 0;
-    for (int i = 0; i < world.size(); i++)
-    {
-      offset[i] = this_offset;
-      if (i == nremainder)
-        nnew--;
-      ParallelStride(world, Particles, this_offset, nnew);
-    }
-    assert(this_offset == Particles.size());
-  }
-}
 inline bool CompParticleId(const Particle_t &a, const Particle_t &b)
 {
   return a.Id < b.Id;
 }
+
+/*
+  This sends each particle to an MPI rank based on the hash of its ID.
+  This is so that when we need to find a particle by ID we can easily
+  compute which rank it is stored on by hashing the ID.
+
+  Within a rank particles are sorted by ID.
+*/
 void ParticleSnapshot_t::ExchangeParticles(MpiWorker_t &world)
 {
 
@@ -161,109 +56,25 @@ void ParticleSnapshot_t::ExchangeParticles(MpiWorker_t &world)
     MPI_Allreduce(&np, &NumberOfParticlesOnAllNodes, 1, MPI_HBT_INT, MPI_SUM, world.Communicator);
   }
 
-  MPI_Barrier(world.Communicator);
-
-  sort(Particles.begin(), Particles.end(), CompParticleId);
-
-  MPI_Barrier(world.Communicator);
-
-  vector<int> SendOffsets(world.size() + 1), SendSizes(world.size(), 0);
+  vector<HBTInt> SendOffsets(world.size() + 1), SendSizes(world.size(), 0);
   PartitionParticles(world, SendOffsets);
   SendOffsets.back() = Particles.size();
   for (int i = 0; i < world.size(); i++)
     SendSizes[i] = SendOffsets[i + 1] - SendOffsets[i];
 
-  vector<int> ReceiveSizes(world.size(), 0), ReceiveOffsets(world.size());
-  MPI_Alltoall(SendSizes.data(), 1, MPI_INT, ReceiveSizes.data(), 1, MPI_INT, world.Communicator);
+  vector<HBTInt> ReceiveSizes(world.size(), 0), ReceiveOffsets(world.size());
+  MPI_Alltoall(SendSizes.data(), 1, MPI_HBT_INT, ReceiveSizes.data(), 1, MPI_HBT_INT, world.Communicator);
   vector<Particle_t> ReceivedParticles;
   ReceivedParticles.resize(CompileOffsets(ReceiveSizes, ReceiveOffsets));
 
   MPI_Datatype MPI_HBT_Particle;
   Particle_t().create_MPI_type(MPI_HBT_Particle);
 
-  MPI_Barrier(world.Communicator);
-
-  // Sanity check
-  {
-    int i;
-    for (i = 0; i < world.size(); i += 1)
-    {
-      // Check overflow
-      if (SendOffsets[i] < 0)
-      {
-        cout << "SendOffset overflow!" << endl;
-        MPI_Abort(world.Communicator, 1);
-      }
-      if (ReceiveOffsets[i] < 0)
-      {
-        cout << "ReceiveOffset overflow!" << endl;
-        MPI_Abort(world.Communicator, 1);
-      }
-      if (SendSizes[i] < 0)
-      {
-        cout << "SendSize overflow!" << endl;
-        MPI_Abort(world.Communicator, 1);
-      }
-      if (ReceiveSizes[i] < 0)
-      {
-        cout << "ReceiveSize overflow!" << endl;
-        MPI_Abort(world.Communicator, 1);
-      }
-      // Check bounds
-      if (SendOffsets[i] + SendSizes[i] > Particles.size())
-      {
-        cout << "SendOffset out of bounds!" << endl;
-        MPI_Abort(world.Communicator, 1);
-      }
-      if (ReceiveOffsets[i] + ReceiveSizes[i] > ReceivedParticles.size())
-      {
-        cout << "ReceiveOffset out of bounds!" << endl;
-        MPI_Abort(world.Communicator, 1);
-      }
-      // Check offsets are monotonic
-      if (i > 0)
-      {
-        if (SendOffsets[i] < SendOffsets[i - 1])
-        {
-          cout << "SendOffset not increasing!" << endl;
-          MPI_Abort(world.Communicator, 1);
-        }
-        if (SendOffsets[i - 1] + SendSizes[i - 1] - 1 >= SendOffsets[i])
-        {
-          cout << "SendOffsets overlap!" << endl;
-          MPI_Abort(world.Communicator, 1);
-        }
-        if (ReceiveOffsets[i] < ReceiveOffsets[i - 1])
-        {
-          cout << "ReceiveOffset not increasing!" << endl;
-          MPI_Abort(world.Communicator, 1);
-        }
-        if (ReceiveOffsets[i - 1] + ReceiveSizes[i - 1] - 1 >= ReceiveOffsets[i])
-        {
-          cout << "ReceiveOffsets overlap!" << endl;
-          MPI_Abort(world.Communicator, 1);
-        }
-      }
-    }
-  }
-
   Pairwise_Alltoallv(Particles, SendSizes, SendOffsets, MPI_HBT_Particle, ReceivedParticles,
                      ReceiveSizes, ReceiveOffsets, MPI_HBT_Particle, world.Communicator);
-
-  MPI_Barrier(world.Communicator);
-
   MPI_Type_free(&MPI_HBT_Particle);
 
   Particles.swap(ReceivedParticles);
 
   sort(Particles.begin(), Particles.end(), CompParticleId);
-  IdMin = Particles.front().Id;
-  IdMax = Particles.back().Id;
-  ProcessIdRanges.resize(world.size() + 1);
-  MPI_Allgather(&IdMin, 1, MPI_HBT_INT, ProcessIdRanges.data(), 1, MPI_HBT_INT, world.Communicator);
-  ProcessIdRanges.back() = IdMax + 1;
-  MPI_Bcast(&ProcessIdRanges.back(), 1, MPI_HBT_INT, world.size() - 1, world.Communicator);
-
-  //   cout<<Particles.size()<<" particles received on node "<<world.rank()<<": IdRange=("<<IdMin<<","<<IdMax<<")
-  //   "<<endl;
 }

--- a/src/snapshot_exchanger.cpp
+++ b/src/snapshot_exchanger.cpp
@@ -31,9 +31,9 @@ inline int AssignCell(HBTxyz &Pos, const HBTReal step[3], const vector<int> &dim
   return GRIDtoRank(GID(0), GID(1), GID(2));
 }
 
-void ParticleSnapshot_t::PartitionParticles(MpiWorker_t &world, vector<HBTInt> &offset)
+vector<HBTInt> ParticleSnapshot_t::PartitionParticles(MpiWorker_t &world)
 {
-  offset = sort_by_hash(Particles, world.size());
+  return sort_by_hash(Particles, world.size());
 }
 
 inline bool CompParticleId(const Particle_t &a, const Particle_t &b)
@@ -56,9 +56,9 @@ void ParticleSnapshot_t::ExchangeParticles(MpiWorker_t &world)
     MPI_Allreduce(&np, &NumberOfParticlesOnAllNodes, 1, MPI_HBT_INT, MPI_SUM, world.Communicator);
   }
 
-  vector<HBTInt> SendOffsets(world.size() + 1), SendSizes(world.size(), 0);
-  PartitionParticles(world, SendOffsets);
-  SendOffsets.back() = Particles.size();
+  vector<HBTInt> SendOffsets = PartitionParticles(world);
+  SendOffsets.push_back(Particles.size());
+  vector<HBTInt> SendSizes(world.size(), 0);
   for (int i = 0; i < world.size(); i++)
     SendSizes[i] = SendOffsets[i + 1] - SendOffsets[i];
 

--- a/src/sort_by_hash.h
+++ b/src/sort_by_hash.h
@@ -9,19 +9,23 @@
 
   Returns an array with the offset to the first particle to go to each rank.
 */
-template <typename Particle_t> std::vector<HBTInt> sort_by_hash(std::vector<Particle_t> &Particles, int comm_size) {
+template <typename Particle_t>
+std::vector<HBTInt> sort_by_hash(std::vector<Particle_t> &Particles, int comm_size)
+{
 
   // First we need to count the number of elements to send to each rank
   std::vector<HBTInt> count(comm_size, 0);
-  for(HBTInt i=0; i<Particles.size(); i+=1) {
+  for (HBTInt i = 0; i < Particles.size(); i += 1)
+  {
     int dest = RankFromIdHash(Particles[i].Id, comm_size);
     count[dest] += 1;
   }
 
   // Compute offset to the first particle for each rank in the output
   std::vector<HBTInt> offset(comm_size, 0);
-  for(int i=1; i<comm_size; i+=1) {
-    offset[i] = offset[i-1] + count[i-1];
+  for (int i = 1; i < comm_size; i += 1)
+  {
+    offset[i] = offset[i - 1] + count[i - 1];
   }
 
   // Allocate storage for the sorted array
@@ -29,10 +33,11 @@ template <typename Particle_t> std::vector<HBTInt> sort_by_hash(std::vector<Part
 
   // Reset the counts
   std::fill(count.begin(), count.end(), 0);
-  
+
   // Populate the output array in sorted order
   // TODO: can we parallelize this somehow?
-  for(HBTInt i=0; i<Particles.size(); i+=1) {
+  for (HBTInt i = 0; i < Particles.size(); i += 1)
+  {
     int dest = RankFromIdHash(Particles[i].Id, comm_size);
     HBTInt j = offset[dest] + count[dest];
     SortedParticles[j] = Particles[i];
@@ -41,6 +46,6 @@ template <typename Particle_t> std::vector<HBTInt> sort_by_hash(std::vector<Part
 
   // Replace the original array
   Particles.swap(SortedParticles);
-  
+
   return offset;
 }

--- a/src/sort_by_hash.h
+++ b/src/sort_by_hash.h
@@ -1,0 +1,46 @@
+#include <vector>
+#include "datatypes.h"
+#include "hash_integers.h"
+
+/*
+  Sort an array of particles by destination rank, where the destination MPI
+  rank is determined by (HashInteger(p.Id) % comm_size). The input Particle_t type
+  should have an Id field.
+
+  Returns an array with the offset to the first particle to go to each rank.
+*/
+template <typename Particle_t> std::vector<HBTInt> sort_by_hash(std::vector<Particle_t> &Particles, int comm_size) {
+
+  // First we need to count the number of elements to send to each rank
+  std::vector<HBTInt> count(comm_size, 0);
+  for(HBTInt i=0; i<Particles.size(); i+=1) {
+    int dest = std::abs(HashInteger(Particles[i].Id)) % comm_size;
+    count[dest] += 1;
+  }
+
+  // Compute offset to the first particle for each rank in the output
+  std::vector<HBTInt> offset(comm_size, 0);
+  for(int i=1; i<comm_size; i+=1) {
+    offset[i] = offset[i-1] + count[i-1];
+  }
+
+  // Allocate storage for the sorted array
+  std::vector<Particle_t> SortedParticles(Particles.size());
+
+  // Reset the counts
+  std::fill(count.begin(), count.end(), 0);
+  
+  // Populate the output array in sorted order
+  // TODO: can we parallelize this somehow?
+  for(HBTInt i=0; i<Particles.size(); i+=1) {
+    int dest = std::abs(HashInteger(Particles[i].Id)) % comm_size;
+    HBTInt j = offset[dest] + count[dest];
+    SortedParticles[j] = Particles[i];
+    count[dest] += 1;
+  }
+
+  // Replace the original array
+  Particles.swap(SortedParticles);
+  
+  return offset;
+}

--- a/src/sort_by_hash.h
+++ b/src/sort_by_hash.h
@@ -14,7 +14,7 @@ template <typename Particle_t> std::vector<HBTInt> sort_by_hash(std::vector<Part
   // First we need to count the number of elements to send to each rank
   std::vector<HBTInt> count(comm_size, 0);
   for(HBTInt i=0; i<Particles.size(); i+=1) {
-    int dest = std::abs(HashInteger(Particles[i].Id)) % comm_size;
+    int dest = RankFromIdHash(Particles[i].Id, comm_size);
     count[dest] += 1;
   }
 
@@ -33,7 +33,7 @@ template <typename Particle_t> std::vector<HBTInt> sort_by_hash(std::vector<Part
   // Populate the output array in sorted order
   // TODO: can we parallelize this somehow?
   for(HBTInt i=0; i<Particles.size(); i+=1) {
-    int dest = std::abs(HashInteger(Particles[i].Id)) % comm_size;
+    int dest = RankFromIdHash(Particles[i].Id, comm_size);
     HBTInt j = offset[dest] + count[dest];
     SortedParticles[j] = Particles[i];
     count[dest] += 1;

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -104,15 +104,19 @@ struct CompareMass_t
   }
   bool operator()(const HBTInt &i, const HBTInt &j)
   {
-    const float mass_i = (*Subhalos)[i].Mbound;
-    const float vmax_i = (*Subhalos)[i].VmaxPhysical;
-    const float mass_j = (*Subhalos)[j].Mbound;
-    const float vmax_j = (*Subhalos)[j].VmaxPhysical;
-    if(mass_i == mass_j) {
-      return (vmax_i > vmax_j);
-    } else {
-      return (mass_i > mass_j);
-    }    
+    const Subhalo_t &sub1 = (*Subhalos)[i];
+    const Subhalo_t &sub2 = (*Subhalos)[j];
+
+    // Try to compare by mass first
+    if(sub1.Mbound != sub1.Mbound)
+      return sub1.Mbound > sub2.Mbound;
+
+    // Where masses are equal, check vmax
+    if(sub1.VmaxPhysical != sub1.VmaxPhysical)
+      return sub1.VmaxPhysical > sub2.VmaxPhysical;
+    
+    // If Mass and Vmax are equal, fall back to most bound particle ID
+    return sub1.MostBoundParticleId > sub2.MostBoundParticleId; 
   }
 };
 void MemberShipTable_t::SortMemberLists(const SubhaloList_t &Subhalos)

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -115,8 +115,8 @@ struct CompareMass_t
     if(sub1.VmaxPhysical != sub2.VmaxPhysical)
       return sub1.VmaxPhysical > sub2.VmaxPhysical;
     
-    // If Mass and Vmax are equal, fall back to most bound particle ID
-    return sub1.MostBoundParticleId > sub2.MostBoundParticleId; 
+    // Otherwise fall back to using the TrackId, which is always unique
+    return sub1.TrackId > sub2.TrackId;
   }
 };
 void MemberShipTable_t::SortMemberLists(const SubhaloList_t &Subhalos)

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -108,11 +108,11 @@ struct CompareMass_t
     const Subhalo_t &sub2 = (*Subhalos)[j];
 
     // Try to compare by mass first
-    if(sub1.Mbound != sub1.Mbound)
+    if(sub1.Mbound != sub2.Mbound)
       return sub1.Mbound > sub2.Mbound;
 
     // Where masses are equal, check vmax
-    if(sub1.VmaxPhysical != sub1.VmaxPhysical)
+    if(sub1.VmaxPhysical != sub2.VmaxPhysical)
       return sub1.VmaxPhysical > sub2.VmaxPhysical;
     
     // If Mass and Vmax are equal, fall back to most bound particle ID

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -108,17 +108,17 @@ struct CompareMass_t
     const Subhalo_t &sub2 = (*Subhalos)[j];
 
     // Try to compare by mass first
-    if(sub1.Mbound != sub2.Mbound)
+    if (sub1.Mbound != sub2.Mbound)
       return sub1.Mbound > sub2.Mbound;
 
     // Where masses are equal, check vmax
-    if(sub1.VmaxPhysical != sub2.VmaxPhysical)
+    if (sub1.VmaxPhysical != sub2.VmaxPhysical)
       return sub1.VmaxPhysical > sub2.VmaxPhysical;
 
     // Where Vmax is equal try most bound ID
-    if(sub1.MostBoundParticleId != sub2.MostBoundParticleId)
+    if (sub1.MostBoundParticleId != sub2.MostBoundParticleId)
       return sub1.MostBoundParticleId > sub2.MostBoundParticleId;
-    
+
     // Otherwise fall back to using the TrackId, which is always unique
     return sub1.TrackId > sub2.TrackId;
   }

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -114,6 +114,10 @@ struct CompareMass_t
     // Where masses are equal, check vmax
     if(sub1.VmaxPhysical != sub2.VmaxPhysical)
       return sub1.VmaxPhysical > sub2.VmaxPhysical;
+
+    // Where Vmax is equal try most bound ID
+    if(sub1.MostBoundParticleId != sub2.MostBoundParticleId)
+      return sub1.MostBoundParticleId > sub2.MostBoundParticleId;
     
     // Otherwise fall back to using the TrackId, which is always unique
     return sub1.TrackId > sub2.TrackId;

--- a/src/subhalo_update_mostbound.cpp
+++ b/src/subhalo_update_mostbound.cpp
@@ -42,7 +42,7 @@ void SubhaloSnapshot_t::UpdateMostBoundPosition(MpiWorker_t &world, const Partic
       ZeroSizeSubhalo[nr_zero].Particles[0] = Particle_t(sub.MostBoundParticleId);
 #ifndef NDEBUG
       // In Debug mode ParticleExchanger_t::QueryParticles() will fail an
-      // assert() if any DM particle is not found. Here we set Type=TypeMax
+      // assert() if any tracer particle is not found. Here we set Type=TypeMax
       // to indicate that we don't know the particle type so it's ok if we
       // can't find it - it might have genuinely disappeared.
       ZeroSizeSubhalo[nr_zero].Particles[0].Type = TypeMax; // Particle type is not known

--- a/src/subhalo_update_mostbound.cpp
+++ b/src/subhalo_update_mostbound.cpp
@@ -41,6 +41,10 @@ void SubhaloSnapshot_t::UpdateMostBoundPosition(MpiWorker_t &world, const Partic
       ZeroSizeSubhalo[nr_zero].Particles.resize(1);
       ZeroSizeSubhalo[nr_zero].Particles[0] = Particle_t(sub.MostBoundParticleId);
 #ifndef NDEBUG
+      // In Debug mode ParticleExchanger_t::QueryParticles() will fail an
+      // assert() if any DM particle is not found. Here we set Type=TypeMax
+      // to indicate that we don't know the particle type so it's ok if we
+      // can't find it - it might have genuinely disappeared.
       ZeroSizeSubhalo[nr_zero].Particles[0].Type = TypeMax; // Particle type is not known
 #endif
       for (int j = 0; j < 3; j += 1)

--- a/src/subhalo_update_mostbound.cpp
+++ b/src/subhalo_update_mostbound.cpp
@@ -40,6 +40,9 @@ void SubhaloSnapshot_t::UpdateMostBoundPosition(MpiWorker_t &world, const Partic
       ZeroSizeSubhalo[nr_zero] = sub;
       ZeroSizeSubhalo[nr_zero].Particles.resize(1);
       ZeroSizeSubhalo[nr_zero].Particles[0] = Particle_t(sub.MostBoundParticleId);
+#ifndef NDEBUG
+      ZeroSizeSubhalo[nr_zero].Particles[0].Type = TypeMax; // Particle type is not known
+#endif
       nr_zero += 1;
     }
   }

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(testfuncs OBJECT
 foreach(TEST_NAME
     test_build_pos_vel
     test_argsort
+    test_sort_by_hash
   )
 
   add_executable(${TEST_NAME} ${TEST_NAME}.cpp $<TARGET_OBJECTS:hbtfuncs> $<TARGET_OBJECTS:testfuncs>)

--- a/unit_tests/test_sort_by_hash.cpp
+++ b/unit_tests/test_sort_by_hash.cpp
@@ -8,22 +8,25 @@
 
 int main(int argc, char *argv[])
 {
-  
+
   // Set up repeatable RNG
   std::mt19937 rng;
   rng.seed(0);
 
-  for(int comm_size=1; comm_size<20; comm_size+=1) {
-  
+  for (int comm_size = 1; comm_size < 20; comm_size += 1)
+  {
+
     // Make an array of fake particles
-    typedef struct {
+    typedef struct
+    {
       HBTInt Id;
     } Particle_t;
     const HBTInt N = 100000;
     std::vector<Particle_t> Particle(N);
 
     // Assign IDs
-    for(HBTInt i=0; i<N; i+=1) {
+    for (HBTInt i = 0; i < N; i += 1)
+    {
       Particle[i].Id = i;
     }
 
@@ -34,32 +37,37 @@ int main(int argc, char *argv[])
     std::vector<HBTInt> offset = sort_by_hash(Particle, comm_size);
 
     // Verify that output is ordered correctly
-    for(HBTInt i=1; i<N; i+=1) {      
-      int dest1 = RankFromIdHash(Particle[i-1].Id, comm_size);
+    for (HBTInt i = 1; i < N; i += 1)
+    {
+      int dest1 = RankFromIdHash(Particle[i - 1].Id, comm_size);
       int dest2 = RankFromIdHash(Particle[i].Id, comm_size);
       verify(dest2 >= dest1);
     }
-  
+
     // Verify that offsets are correct
     HBTInt nr_correct = 0;
-    for(int i=0; i<comm_size; i+=1) {
+    for (int i = 0; i < comm_size; i += 1)
+    {
       HBTInt start = offset[i];
       HBTInt end;
-      if(i<comm_size-1) {
-        end = offset[i+1];
-      } else {
+      if (i < comm_size - 1)
+      {
+        end = offset[i + 1];
+      }
+      else
+      {
         end = N;
       }
       HBTInt num = end - start;
-      for(HBTInt j=0; j<num; j+=1) {
-        int dest = RankFromIdHash(Particle[start+j].Id, comm_size);
-        verify(dest==i);
+      for (HBTInt j = 0; j < num; j += 1)
+      {
+        int dest = RankFromIdHash(Particle[start + j].Id, comm_size);
+        verify(dest == i);
         nr_correct += 1;
       }
     }
-    verify(nr_correct==N); // Should have checked every particle
-    
+    verify(nr_correct == N); // Should have checked every particle
   }
-  
+
   return 0;
 }

--- a/unit_tests/test_sort_by_hash.cpp
+++ b/unit_tests/test_sort_by_hash.cpp
@@ -1,0 +1,61 @@
+#include <random>
+#include <iostream>
+#include <cmath>
+#include <algorithm>
+
+#include "sort_by_hash.h"
+#include "verify.h"
+
+int main(int argc, char *argv[])
+{
+  
+  // Set up repeatable RNG
+  std::mt19937 rng;
+  rng.seed(0);
+
+  for(int comm_size=1; comm_size<20; comm_size+=1) {
+  
+    // Make an array of fake particles
+    typedef struct {
+      HBTInt Id;
+    } Particle_t;
+    const HBTInt N = 100000;
+    std::vector<Particle_t> Particle(N);
+
+    // Assign IDs
+    for(HBTInt i=0; i<N; i+=1) {
+      Particle[i].Id = i;
+    }
+
+    // Scramble ordering
+    std::shuffle(Particle.begin(), Particle.end(), rng);
+
+    // Sort by hash and compute offsets
+    std::vector<HBTInt> offset = sort_by_hash(Particle, comm_size);
+
+    // Verify that output is ordered correctly
+    for(HBTInt i=1; i<N; i+=1) {
+      int dest1 = std::abs(HashInteger(Particle[i-1].Id)) % comm_size;
+      int dest2 = std::abs(HashInteger(Particle[i].Id)) % comm_size;
+      verify(dest2 >= dest1);
+    }
+  
+    // Verify that offsets are correct
+    for(int i=0; i<comm_size; i+=1) {
+      HBTInt start = offset[i];
+      HBTInt end;
+      if(i<comm_size-1) {
+        end = offset[i+1];
+      } else {
+        end = N;
+      }
+      HBTInt num = end - start;
+      for(HBTInt j=0; j<num; j+=1) {
+        int dest = std::abs(HashInteger(Particle[start+j].Id)) % comm_size;
+      verify(dest==i);
+      }
+    }
+  }
+  
+  return 0;
+}

--- a/unit_tests/test_sort_by_hash.cpp
+++ b/unit_tests/test_sort_by_hash.cpp
@@ -34,9 +34,9 @@ int main(int argc, char *argv[])
     std::vector<HBTInt> offset = sort_by_hash(Particle, comm_size);
 
     // Verify that output is ordered correctly
-    for(HBTInt i=1; i<N; i+=1) {
-      int dest1 = std::abs(HashInteger(Particle[i-1].Id)) % comm_size;
-      int dest2 = std::abs(HashInteger(Particle[i].Id)) % comm_size;
+    for(HBTInt i=1; i<N; i+=1) {      
+      int dest1 = RankFromIdHash(Particle[i-1].Id, comm_size);
+      int dest2 = RankFromIdHash(Particle[i].Id, comm_size);
       verify(dest2 >= dest1);
     }
   
@@ -51,8 +51,8 @@ int main(int argc, char *argv[])
       }
       HBTInt num = end - start;
       for(HBTInt j=0; j<num; j+=1) {
-        int dest = std::abs(HashInteger(Particle[start+j].Id)) % comm_size;
-      verify(dest==i);
+        int dest = RankFromIdHash(Particle[start+j].Id, comm_size);
+        verify(dest==i);
       }
     }
   }

--- a/unit_tests/test_sort_by_hash.cpp
+++ b/unit_tests/test_sort_by_hash.cpp
@@ -41,6 +41,7 @@ int main(int argc, char *argv[])
     }
   
     // Verify that offsets are correct
+    HBTInt nr_correct = 0;
     for(int i=0; i<comm_size; i+=1) {
       HBTInt start = offset[i];
       HBTInt end;
@@ -53,8 +54,11 @@ int main(int argc, char *argv[])
       for(HBTInt j=0; j<num; j+=1) {
         int dest = RankFromIdHash(Particle[start+j].Id, comm_size);
         verify(dest==i);
+        nr_correct += 1;
       }
     }
+    verify(nr_correct==N); // Should have checked every particle
+    
   }
   
   return 0;

--- a/unit_tests/test_sort_by_hash.cpp
+++ b/unit_tests/test_sort_by_hash.cpp
@@ -13,7 +13,7 @@ int main(int argc, char *argv[])
   std::mt19937 rng;
   rng.seed(0);
 
-  for (int comm_size = 1; comm_size < 20; comm_size += 1)
+  for (int number_partitions = 1; number_partitions < 20; number_partitions += 1)
   {
 
     // Make an array of fake particles
@@ -34,23 +34,23 @@ int main(int argc, char *argv[])
     std::shuffle(Particle.begin(), Particle.end(), rng);
 
     // Sort by hash and compute offsets
-    std::vector<HBTInt> offset = sort_by_hash(Particle, comm_size);
+    std::vector<HBTInt> offset = sort_by_hash(Particle, number_partitions);
 
     // Verify that output is ordered correctly
     for (HBTInt i = 1; i < N; i += 1)
     {
-      int dest1 = RankFromIdHash(Particle[i - 1].Id, comm_size);
-      int dest2 = RankFromIdHash(Particle[i].Id, comm_size);
+      int dest1 = RankFromIdHash(Particle[i - 1].Id, number_partitions);
+      int dest2 = RankFromIdHash(Particle[i].Id, number_partitions);
       verify(dest2 >= dest1);
     }
 
     // Verify that offsets are correct
     HBTInt nr_correct = 0;
-    for (int i = 0; i < comm_size; i += 1)
+    for (int i = 0; i < number_partitions; i += 1)
     {
       HBTInt start = offset[i];
       HBTInt end;
-      if (i < comm_size - 1)
+      if (i < number_partitions - 1)
       {
         end = offset[i + 1];
       }
@@ -61,7 +61,7 @@ int main(int argc, char *argv[])
       HBTInt num = end - start;
       for (HBTInt j = 0; j < num; j += 1)
       {
-        int dest = RankFromIdHash(Particle[start + j].Id, comm_size);
+        int dest = RankFromIdHash(Particle[start + j].Id, number_partitions);
         verify(dest == i);
         nr_correct += 1;
       }


### PR DESCRIPTION
Currently HBT arranges snapshot particles for easy lookup by ID by putting different ranges of IDs on different MPI ranks. The algorithm used to determine the assignment of ID ranges to ranks seems to become very slow on hydro runs where the IDs are not a contiguous sequence.

This pull request modifies the code to distribute particles according to the hash of their ID. Assigning particles to ranks is then just done by `rank = hash(id) % comm_size`, which is simple and fast but we rely on the hash values being evenly distributed to ensure reasonable load balancing.
