### PR TITLE
Small fixes and unit tests for MyAllToAll()

### DIFF
--- a/src/mpi_wrapper.h
+++ b/src/mpi_wrapper.h
@@ -174,7 +174,7 @@ void MyAllToAll(MpiWorker_t &world, vector<InParticleIterator_T> InParticleItera
                    world.Communicator);
 
     // Allocate receive buffer
-    HBTInt RecvCountTotal = std::accumulate(RecvParticleCounts.begin(), RecvParticleCounts.end(), 0);    
+    HBTInt RecvCountTotal = std::accumulate(RecvParticleCounts.begin(), RecvParticleCounts.end(), (HBTInt) 0);    
     RecvBuffer.resize(RecvCountTotal);
     
     // pack

--- a/src/mpi_wrapper.h
+++ b/src/mpi_wrapper.h
@@ -129,7 +129,7 @@ void VectorAllToAll(MpiWorker_t &world, vector<vector<T>> &SendVecs, vector<vect
 template <class Particle_T, class InParticleIterator_T, class OutParticleIterator_T>
 void MyAllToAll(MpiWorker_t &world, vector<InParticleIterator_T> InParticleIterator,
                 const vector<HBTInt> &InParticleCount, vector<OutParticleIterator_T> OutParticleIterator,
-                MPI_Datatype MPI_Particle_T)
+                MPI_Datatype MPI_Particle_T, const HBTInt chunksize=1024*1024)
 /*break the task into smaller pieces to avoid message size overflow
  * allocate a temporary buffer of type Particle_T to copy from InParticleIterator, send around, and copy out to
  OutParticleIterator. InParticleIterator should point to data directly assignable to Particle_T. OutParticleIterator
@@ -137,7 +137,6 @@ void MyAllToAll(MpiWorker_t &world, vector<InParticleIterator_T> InParticleItera
  */
 {
   // determine loops
-  const HBTInt chunksize = 1024 * 1024;
   HBTInt InParticleSum = accumulate(InParticleCount.begin(), InParticleCount.end(), (HBTInt)0);
   HBTInt Nloop = InParticleSum / chunksize;
   if((InParticleSum % chunksize) != 0)Nloop += 1;

--- a/src/pairwise_alltoallv.h
+++ b/src/pairwise_alltoallv.h
@@ -11,7 +11,8 @@
 */
 template<typename T>
 int Pairwise_Alltoallv(const void *sendbuf, const T *sendcounts, const T *sdispls, MPI_Datatype sendtype,
-                       void *recvbuf, const T *recvcounts, const T *rdispls, MPI_Datatype recvtype, MPI_Comm comm)
+                       void *recvbuf, const T *recvcounts, const T *rdispls, MPI_Datatype recvtype,
+                       MPI_Comm comm, const size_t max_send_size = (1 << 30))
 {
 
   int comm_size;
@@ -43,7 +44,7 @@ int Pairwise_Alltoallv(const void *sendbuf, const T *sendcounts, const T *sdispl
 
       while (sendcount > 0 || recvcount > 0)
       {
-        size_t max_bytes = 1 << 30;
+        size_t max_bytes = max_send_size;
         size_t max_num_send = max_bytes / send_type_size;
         size_t max_num_recv = max_bytes / recv_type_size;
         size_t num_send = sendcount <= max_num_send ? sendcount : max_num_send;
@@ -79,10 +80,12 @@ int Pairwise_Alltoallv(const void *sendbuf, const T *sendcounts, const T *sdispl
 */
 template<typename T, typename U, typename V>
 int Pairwise_Alltoallv(const std::vector<U> &sendbuf, const std::vector<T> &sendcounts, const std::vector<T> &sdispls, MPI_Datatype sendtype,
-                       std::vector<V> &recvbuf, const std::vector<T> &recvcounts, const std::vector<T> &rdispls, MPI_Datatype recvtype, MPI_Comm comm)
+                       std::vector<V> &recvbuf, const std::vector<T> &recvcounts, const std::vector<T> &rdispls, MPI_Datatype recvtype,
+                       MPI_Comm comm, const size_t max_send_size = (1 << 30))
 {
   return Pairwise_Alltoallv(sendbuf.data(), sendcounts.data(), sdispls.data(), sendtype,
-                            recvbuf.data(), recvcounts.data(), rdispls.data(), recvtype, comm);
+                            recvbuf.data(), recvcounts.data(), rdispls.data(), recvtype,
+                            comm, max_send_size);
 }
 
 /*
@@ -117,7 +120,7 @@ void ExchangeCounts(const std::vector<T> &sendcounts, std::vector<T> &sdispls,
   rdispls[0] = 0;
   for(int i=1; i<comm_size; i+=1) {
     sdispls[i] = sdispls[i-1] + sendcounts[i-1];
-    rdispls[i] = rdispls[i-1] + recvcounts[i-1];    
+    rdispls[i] = rdispls[i-1] + recvcounts[i-1];
   }
 }
 

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -48,6 +48,7 @@ foreach(TEST_NAME
     test_locate_ids_unique
     test_locate_ids_random
     test_mergertree
+    test_myalltoall
   )
 
   add_executable(${TEST_NAME} ${TEST_NAME}.cpp $<TARGET_OBJECTS:hbtfuncs> $<TARGET_OBJECTS:testfuncs>)

--- a/unit_tests/test_myalltoall.cpp
+++ b/unit_tests/test_myalltoall.cpp
@@ -1,9 +1,10 @@
 #include <mpi.h>
 #include <vector>
+#include <random>
 
-#include "datatypes.h"
-#include "verify.h"
 #include "mpi_wrapper.h"
+#include "verify.h"
+#include "pairwise_alltoallv.h"
 
 
 int main(int argc, char *argv[]) {
@@ -15,62 +16,97 @@ int main(int argc, char *argv[]) {
   MPI_Comm_rank(MPI_COMM_WORLD, &comm_rank);
   MpiWorker_t world(MPI_COMM_WORLD);
 
-  // Make an array of counts for other processors
-  std::vector<HBTInt> sendcounts(comm_size);
-  for(int i=0; i<comm_size; i+=1) {
-    sendcounts[i] = 100+comm_rank*50;
-  }
+  // Set up repeatable RNG with different seed on each rank
+  std::mt19937 rng;
+  rng.seed(comm_rank);
 
-  // Allocate the send buffer
-  int nr_local_elements = 0;
-  for(auto n : sendcounts)
-    nr_local_elements += n;
-  std::vector<int> sendbuf(nr_local_elements);
+  const int nr_reps = 1000;
+  for(int rep_nr=0; rep_nr<nr_reps; rep_nr+=1) {
 
-  // Populate the send buffer with index of the source and destination ranks
-  int offset = 0;
-  for(int dest=0; dest<comm_size; dest+=1) {
-    for(int i=0; i<sendcounts[dest]; i+=1) {
-      sendbuf[offset] = comm_rank + 1000*dest;
-      offset += 1;
+    // Determine maximum chunk size for chunking test (all ranks need to agree on this)
+    std::uniform_int_distribution<> send_size_dist(1, 100);
+    int max_send_size = send_size_dist(rng);
+    MPI_Bcast(&max_send_size, 1, MPI_INT, 0, MPI_COMM_WORLD);
+    
+    // Make an array of counts for other processors
+    std::uniform_int_distribution<> dist(0, 100);
+    std::vector<HBTInt> sendcounts(comm_size);
+    for(int i=0; i<comm_size; i+=1) {
+      sendcounts[i] = dist(rng);
+    }
+
+    // Allocate the send buffer
+    int nr_local_elements = 0;
+    for(auto n : sendcounts)
+      nr_local_elements += n;
+    std::vector<int> sendbuf(nr_local_elements);
+
+    // Populate the send buffer with index of the source and destination ranks
+    int offset = 0;
+    for(int dest=0; dest<comm_size; dest+=1) {
+      for(int i=0; i<sendcounts[dest]; i+=1) {
+        sendbuf[offset] = comm_rank + 1000*dest;
+        offset += 1;
+      }
+    }
+  
+    // Compute receive counts and displacements
+    std::vector<HBTInt> senddispls(comm_size);
+    std::vector<HBTInt> recvcounts(comm_size);
+    std::vector<HBTInt> recvdispls(comm_size);
+    ExchangeCounts(sendcounts, senddispls, recvcounts, recvdispls, MPI_COMM_WORLD);
+
+    // Allocate receive buffer
+    int nr_recv = 0;
+    for(auto n : recvcounts)
+      nr_recv += n;
+    std::vector<int> recvbuf(nr_recv);
+
+    // Set up iterators
+    typedef vector<int>::iterator InputIterator_t;
+    std::vector<InputIterator_t> input_iterators(comm_size);
+    for(int i=0; i<comm_size; i+=1) {
+      input_iterators[i] = sendbuf.begin() + senddispls[i];
+    }
+
+    typedef vector<int>::iterator OutputIterator_t;
+    std::vector<OutputIterator_t> output_iterators(comm_size);
+    for(int i=0; i<comm_size; i+=1) {
+      output_iterators[i] = recvbuf.begin() + recvdispls[i];
+    }
+  
+    // Exchange data
+    std::fill(std::begin(recvbuf), std::end(recvbuf), -1);
+    MyAllToAll<int, InputIterator_t, OutputIterator_t>(world, input_iterators, sendcounts, output_iterators, MPI_INT);
+    
+    // Verify result
+    for(int src=0; src<comm_size; src+=1) {
+      for(int i=recvdispls[src]; i<recvdispls[src]+recvcounts[src]; i+=1) {
+        verify(recvbuf[i] == src+1000*comm_rank);
+      }
+    }
+
+    // Try again using small chunks. Need to reset iterators first.
+    for(int i=0; i<comm_size; i+=1) {
+      input_iterators[i] = sendbuf.begin() + senddispls[i];
+    }
+    for(int i=0; i<comm_size; i+=1) {
+      output_iterators[i] = recvbuf.begin() + recvdispls[i];
+    }
+
+    // Exchange data
+    std::fill(std::begin(recvbuf), std::end(recvbuf), -1);
+    MyAllToAll<int, InputIterator_t, OutputIterator_t>(world, input_iterators, sendcounts, output_iterators, MPI_INT,
+                                                       (HBTInt) max_send_size);
+    
+    // Verify result
+    for(int src=0; src<comm_size; src+=1) {
+      for(int i=recvdispls[src]; i<recvdispls[src]+recvcounts[src]; i+=1) {
+        verify(recvbuf[i] == src+1000*comm_rank);
+      }
     }
   }
-  
-  // Compute receive counts and displacements
-  std::vector<HBTInt> senddispls(comm_size);
-  std::vector<HBTInt> recvcounts(comm_size);
-  std::vector<HBTInt> recvdispls(comm_size);
-  ExchangeCounts(sendcounts, senddispls, recvcounts, recvdispls, MPI_COMM_WORLD);
 
-  // Allocate receive buffer
-  int nr_recv = 0;
-  for(auto n : recvcounts)
-    nr_recv += n;
-  std::vector<int> recvbuf(nr_recv);
-
-  // Set up iterators
-  typedef vector<int>::iterator InputIterator_t;
-  std::vector<InputIterator_t> input_iterators(comm_size);
-  for(int i=0; i<comm_size; i+=1) {
-    input_iterators[i] = sendbuf.begin() + senddispls[i];
-  }
-
-  typedef vector<int>::iterator OutputIterator_t;
-  std::vector<OutputIterator_t> output_iterators(comm_size);
-  for(int i=0; i<comm_size; i+=1) {
-    output_iterators[i] = recvbuf.begin() + recvdispls[i];
-  }
-  
-  // Exchange data
-  MyAllToAll<int, InputIterator_t, OutputIterator_t>(world, input_iterators, sendcounts, output_iterators, MPI_INT);
-
-  // Verify result
-  for(int src=0; src<comm_size; src+=1) {
-    for(int i=recvdispls[src]; i<recvdispls[src]+recvcounts[src]; i+=1) {
-      verify(recvbuf[i] == src+1000*comm_rank);
-    }
-  }
-  
   MPI_Finalize();
 
   return 0;

--- a/unit_tests/test_myalltoall.cpp
+++ b/unit_tests/test_myalltoall.cpp
@@ -25,8 +25,8 @@ int main(int argc, char *argv[]) {
 
     // Determine maximum chunk size for chunking test (all ranks need to agree on this)
     std::uniform_int_distribution<> send_size_dist(1, 100);
-    int max_send_size = send_size_dist(rng);
-    MPI_Bcast(&max_send_size, 1, MPI_INT, 0, MPI_COMM_WORLD);
+    int max_send_size_elements = send_size_dist(rng);
+    MPI_Bcast(&max_send_size_elements, 1, MPI_INT, 0, MPI_COMM_WORLD);
     
     // Make an array of counts for other processors
     std::uniform_int_distribution<> dist(0, 100);
@@ -97,7 +97,7 @@ int main(int argc, char *argv[]) {
     // Exchange data
     std::fill(std::begin(recvbuf), std::end(recvbuf), -1);
     MyAllToAll<int, InputIterator_t, OutputIterator_t>(world, input_iterators, sendcounts, output_iterators, MPI_INT,
-                                                       (HBTInt) max_send_size);
+                                                       (HBTInt) max_send_size_elements);
     
     // Verify result
     for(int src=0; src<comm_size; src+=1) {

--- a/unit_tests/test_myalltoall.cpp
+++ b/unit_tests/test_myalltoall.cpp
@@ -1,0 +1,77 @@
+#include <mpi.h>
+#include <vector>
+
+#include "datatypes.h"
+#include "verify.h"
+#include "mpi_wrapper.h"
+
+
+int main(int argc, char *argv[]) {
+
+  MPI_Init(&argc, &argv);
+  int comm_size;
+  MPI_Comm_size(MPI_COMM_WORLD, &comm_size);
+  int comm_rank;
+  MPI_Comm_rank(MPI_COMM_WORLD, &comm_rank);
+  MpiWorker_t world(MPI_COMM_WORLD);
+
+  // Make an array of counts for other processors
+  std::vector<HBTInt> sendcounts(comm_size);
+  for(int i=0; i<comm_size; i+=1) {
+    sendcounts[i] = 100+comm_rank*50;
+  }
+
+  // Allocate the send buffer
+  int nr_local_elements = 0;
+  for(auto n : sendcounts)
+    nr_local_elements += n;
+  std::vector<int> sendbuf(nr_local_elements);
+
+  // Populate the send buffer with index of the source and destination ranks
+  int offset = 0;
+  for(int dest=0; dest<comm_size; dest+=1) {
+    for(int i=0; i<sendcounts[dest]; i+=1) {
+      sendbuf[offset] = comm_rank + 1000*dest;
+      offset += 1;
+    }
+  }
+  
+  // Compute receive counts and displacements
+  std::vector<HBTInt> senddispls(comm_size);
+  std::vector<HBTInt> recvcounts(comm_size);
+  std::vector<HBTInt> recvdispls(comm_size);
+  ExchangeCounts(sendcounts, senddispls, recvcounts, recvdispls, MPI_COMM_WORLD);
+
+  // Allocate receive buffer
+  int nr_recv = 0;
+  for(auto n : recvcounts)
+    nr_recv += n;
+  std::vector<int> recvbuf(nr_recv);
+
+  // Set up iterators
+  typedef vector<int>::iterator InputIterator_t;
+  std::vector<InputIterator_t> input_iterators(comm_size);
+  for(int i=0; i<comm_size; i+=1) {
+    input_iterators[i] = sendbuf.begin() + senddispls[i];
+  }
+
+  typedef vector<int>::iterator OutputIterator_t;
+  std::vector<OutputIterator_t> output_iterators(comm_size);
+  for(int i=0; i<comm_size; i+=1) {
+    output_iterators[i] = recvbuf.begin() + recvdispls[i];
+  }
+  
+  // Exchange data
+  MyAllToAll<int, InputIterator_t, OutputIterator_t>(world, input_iterators, sendcounts, output_iterators, MPI_INT);
+
+  // Verify result
+  for(int src=0; src<comm_size; src+=1) {
+    for(int i=recvdispls[src]; i<recvdispls[src]+recvcounts[src]; i+=1) {
+      verify(recvbuf[i] == src+1000*comm_rank);
+    }
+  }
+  
+  MPI_Finalize();
+
+  return 0;
+}

--- a/unit_tests/test_myalltoall.cpp
+++ b/unit_tests/test_myalltoall.cpp
@@ -6,8 +6,8 @@
 #include "verify.h"
 #include "pairwise_alltoallv.h"
 
-
-int main(int argc, char *argv[]) {
+int main(int argc, char *argv[])
+{
 
   MPI_Init(&argc, &argv);
   int comm_size;
@@ -21,35 +21,39 @@ int main(int argc, char *argv[]) {
   rng.seed(comm_rank);
 
   const int nr_reps = 1000;
-  for(int rep_nr=0; rep_nr<nr_reps; rep_nr+=1) {
+  for (int rep_nr = 0; rep_nr < nr_reps; rep_nr += 1)
+  {
 
     // Determine maximum chunk size for chunking test (all ranks need to agree on this)
     std::uniform_int_distribution<> send_size_dist(1, 100);
     int max_send_size_elements = send_size_dist(rng);
     MPI_Bcast(&max_send_size_elements, 1, MPI_INT, 0, MPI_COMM_WORLD);
-    
+
     // Make an array of counts for other processors
     std::uniform_int_distribution<> dist(0, 100);
     std::vector<HBTInt> sendcounts(comm_size);
-    for(int i=0; i<comm_size; i+=1) {
+    for (int i = 0; i < comm_size; i += 1)
+    {
       sendcounts[i] = dist(rng);
     }
 
     // Allocate the send buffer
     int nr_local_elements = 0;
-    for(auto n : sendcounts)
+    for (auto n : sendcounts)
       nr_local_elements += n;
     std::vector<int> sendbuf(nr_local_elements);
 
     // Populate the send buffer with index of the source and destination ranks
     int offset = 0;
-    for(int dest=0; dest<comm_size; dest+=1) {
-      for(int i=0; i<sendcounts[dest]; i+=1) {
-        sendbuf[offset] = comm_rank + 1000*dest;
+    for (int dest = 0; dest < comm_size; dest += 1)
+    {
+      for (int i = 0; i < sendcounts[dest]; i += 1)
+      {
+        sendbuf[offset] = comm_rank + 1000 * dest;
         offset += 1;
       }
     }
-  
+
     // Compute receive counts and displacements
     std::vector<HBTInt> senddispls(comm_size);
     std::vector<HBTInt> recvcounts(comm_size);
@@ -58,51 +62,59 @@ int main(int argc, char *argv[]) {
 
     // Allocate receive buffer
     int nr_recv = 0;
-    for(auto n : recvcounts)
+    for (auto n : recvcounts)
       nr_recv += n;
     std::vector<int> recvbuf(nr_recv);
 
     // Set up iterators
     typedef vector<int>::iterator InputIterator_t;
     std::vector<InputIterator_t> input_iterators(comm_size);
-    for(int i=0; i<comm_size; i+=1) {
+    for (int i = 0; i < comm_size; i += 1)
+    {
       input_iterators[i] = sendbuf.begin() + senddispls[i];
     }
 
     typedef vector<int>::iterator OutputIterator_t;
     std::vector<OutputIterator_t> output_iterators(comm_size);
-    for(int i=0; i<comm_size; i+=1) {
+    for (int i = 0; i < comm_size; i += 1)
+    {
       output_iterators[i] = recvbuf.begin() + recvdispls[i];
     }
-  
+
     // Exchange data
     std::fill(std::begin(recvbuf), std::end(recvbuf), -1);
     MyAllToAll<int, InputIterator_t, OutputIterator_t>(world, input_iterators, sendcounts, output_iterators, MPI_INT);
-    
+
     // Verify result
-    for(int src=0; src<comm_size; src+=1) {
-      for(int i=recvdispls[src]; i<recvdispls[src]+recvcounts[src]; i+=1) {
-        verify(recvbuf[i] == src+1000*comm_rank);
+    for (int src = 0; src < comm_size; src += 1)
+    {
+      for (int i = recvdispls[src]; i < recvdispls[src] + recvcounts[src]; i += 1)
+      {
+        verify(recvbuf[i] == src + 1000 * comm_rank);
       }
     }
 
     // Try again using small chunks. Need to reset iterators first.
-    for(int i=0; i<comm_size; i+=1) {
+    for (int i = 0; i < comm_size; i += 1)
+    {
       input_iterators[i] = sendbuf.begin() + senddispls[i];
     }
-    for(int i=0; i<comm_size; i+=1) {
+    for (int i = 0; i < comm_size; i += 1)
+    {
       output_iterators[i] = recvbuf.begin() + recvdispls[i];
     }
 
     // Exchange data
     std::fill(std::begin(recvbuf), std::end(recvbuf), -1);
     MyAllToAll<int, InputIterator_t, OutputIterator_t>(world, input_iterators, sendcounts, output_iterators, MPI_INT,
-                                                       (HBTInt) max_send_size_elements);
-    
+                                                       (HBTInt)max_send_size_elements);
+
     // Verify result
-    for(int src=0; src<comm_size; src+=1) {
-      for(int i=recvdispls[src]; i<recvdispls[src]+recvcounts[src]; i+=1) {
-        verify(recvbuf[i] == src+1000*comm_rank);
+    for (int src = 0; src < comm_size; src += 1)
+    {
+      for (int i = recvdispls[src]; i < recvdispls[src] + recvcounts[src]; i += 1)
+      {
+        verify(recvbuf[i] == src + 1000 * comm_rank);
       }
     }
   }

--- a/unit_tests/test_pairwise_alltoallv.cpp
+++ b/unit_tests/test_pairwise_alltoallv.cpp
@@ -22,8 +22,8 @@ int main(int argc, char *argv[]) {
   for(int rep_nr=0; rep_nr<nr_reps; rep_nr+=1) {
 
     // Determine maximum message size for small chunks test (all ranks need to agree on this)
-    std::uniform_int_distribution<> send_size_dist(4, 128);
-    int max_send_size_bytes = send_size_dist(rng);
+    std::uniform_int_distribution<> send_size_dist(1, 100);
+    int max_send_size_bytes = send_size_dist(rng) * ((int) sizeof(int));
     MPI_Bcast(&max_send_size_bytes, 1, MPI_INT, 0, MPI_COMM_WORLD);
     
     // Make an array of counts for other processors

--- a/unit_tests/test_pairwise_alltoallv.cpp
+++ b/unit_tests/test_pairwise_alltoallv.cpp
@@ -1,5 +1,6 @@
 #include <mpi.h>
 #include <vector>
+#include <random>
 
 #include "verify.h"
 #include "pairwise_alltoallv.h"
@@ -13,47 +14,75 @@ int main(int argc, char *argv[]) {
   int comm_rank;
   MPI_Comm_rank(MPI_COMM_WORLD, &comm_rank);
 
-  // Make an array of counts for other processors
-  std::vector<int> sendcounts(comm_size);
-  for(int i=0; i<comm_size; i+=1) {
-    sendcounts[i] = 100+comm_rank*50;
-  }
+  // Set up repeatable RNG with different seed on each rank
+  std::mt19937 rng;
+  rng.seed(comm_rank);
 
-  // Allocate the send buffer
-  int nr_local_elements = 0;
-  for(auto n : sendcounts)
-    nr_local_elements += n;
-  std::vector<int> sendbuf(nr_local_elements);
+  const int nr_reps = 1000;
+  for(int rep_nr=0; rep_nr<nr_reps; rep_nr+=1) {
 
-  // Populate the send buffer with index of the source and destination ranks
-  int offset = 0;
-  for(int dest=0; dest<comm_size; dest+=1) {
-    for(int i=0; i<sendcounts[dest]; i+=1) {
-      sendbuf[offset] = comm_rank + 1000*dest;
-      offset += 1;
+    // Determine maximum message size for small chunks test (all ranks need to agree on this)
+    std::uniform_int_distribution<> send_size_dist(4, 128);
+    int max_send_size = send_size_dist(rng);
+    MPI_Bcast(&max_send_size, 1, MPI_INT, 0, MPI_COMM_WORLD);
+    
+    // Make an array of counts for other processors
+    std::uniform_int_distribution<> dist(0, 100);
+    std::vector<int> sendcounts(comm_size);
+    for(int i=0; i<comm_size; i+=1) {
+      sendcounts[i] = dist(rng);
     }
-  }
+
+    // Allocate the send buffer
+    int nr_local_elements = 0;
+    for(auto n : sendcounts)
+      nr_local_elements += n;
+    std::vector<int> sendbuf(nr_local_elements);
+
+    // Populate the send buffer with index of the source and destination ranks
+    int offset = 0;
+    for(int dest=0; dest<comm_size; dest+=1) {
+      for(int i=0; i<sendcounts[dest]; i+=1) {
+        sendbuf[offset] = comm_rank + 1000*dest;
+        offset += 1;
+      }
+    }
   
-  // Compute receive counts and displacements
-  std::vector<int> senddispls(comm_size);
-  std::vector<int> recvcounts(comm_size);
-  std::vector<int> recvdispls(comm_size);
-  ExchangeCounts(sendcounts, senddispls, recvcounts, recvdispls, MPI_COMM_WORLD);
+    // Compute receive counts and displacements
+    std::vector<int> senddispls(comm_size);
+    std::vector<int> recvcounts(comm_size);
+    std::vector<int> recvdispls(comm_size);
+    ExchangeCounts(sendcounts, senddispls, recvcounts, recvdispls, MPI_COMM_WORLD);
 
-  // Allocate receive buffer
-  int nr_recv = 0;
-  for(auto n : recvcounts)
-    nr_recv += n;
-  std::vector<int> recvbuf(nr_recv);
+    // Allocate receive buffer
+    int nr_recv = 0;
+    for(auto n : recvcounts)
+      nr_recv += n;
+    std::vector<int> recvbuf(nr_recv);
+ 
+    // Exchange data
+    std::fill(std::begin(recvbuf), std::end(recvbuf), -1);
+    Pairwise_Alltoallv(sendbuf, sendcounts, senddispls, MPI_INT,
+                       recvbuf, recvcounts, recvdispls, MPI_INT, MPI_COMM_WORLD);
+    
+    // Verify result
+    for(int src=0; src<comm_size; src+=1) {
+      for(int i=recvdispls[src]; i<recvdispls[src]+recvcounts[src]; i+=1) {
+        verify(recvbuf[i] == src+1000*comm_rank);
+      }
+    }
 
-  // Exchange data
-  Pairwise_Alltoallv(sendbuf, sendcounts, senddispls, MPI_INT,
-                     recvbuf, recvcounts, recvdispls, MPI_INT, MPI_COMM_WORLD);
-
-  // Verify result
-  for(int src=0; src<comm_size; src+=1) {
-    for(int i=recvdispls[src]; i<recvdispls[src]+recvcounts[src]; i+=1) {
-      verify(recvbuf[i] == src+1000*comm_rank);
+    // Try again with a small maximum send size so that we use multiple chunks
+    std::fill(std::begin(recvbuf), std::end(recvbuf), -1);
+    Pairwise_Alltoallv(sendbuf, sendcounts, senddispls, MPI_INT,
+                       recvbuf, recvcounts, recvdispls, MPI_INT, MPI_COMM_WORLD,
+                       (size_t) max_send_size);
+    
+    // Verify result
+    for(int src=0; src<comm_size; src+=1) {
+      for(int i=recvdispls[src]; i<recvdispls[src]+recvcounts[src]; i+=1) {
+        verify(recvbuf[i] == src+1000*comm_rank);
+      }
     }
   }
   

--- a/unit_tests/test_pairwise_alltoallv.cpp
+++ b/unit_tests/test_pairwise_alltoallv.cpp
@@ -23,8 +23,8 @@ int main(int argc, char *argv[]) {
 
     // Determine maximum message size for small chunks test (all ranks need to agree on this)
     std::uniform_int_distribution<> send_size_dist(4, 128);
-    int max_send_size = send_size_dist(rng);
-    MPI_Bcast(&max_send_size, 1, MPI_INT, 0, MPI_COMM_WORLD);
+    int max_send_size_bytes = send_size_dist(rng);
+    MPI_Bcast(&max_send_size_bytes, 1, MPI_INT, 0, MPI_COMM_WORLD);
     
     // Make an array of counts for other processors
     std::uniform_int_distribution<> dist(0, 100);
@@ -76,7 +76,7 @@ int main(int argc, char *argv[]) {
     std::fill(std::begin(recvbuf), std::end(recvbuf), -1);
     Pairwise_Alltoallv(sendbuf, sendcounts, senddispls, MPI_INT,
                        recvbuf, recvcounts, recvdispls, MPI_INT, MPI_COMM_WORLD,
-                       (size_t) max_send_size);
+                       (size_t) max_send_size_bytes);
     
     // Verify result
     for(int src=0; src<comm_size; src+=1) {


### PR DESCRIPTION
There are two things in MyAllToAll which looked like they could be a problem if we're really unlucky:

  * The calculation of Nloop involves an unnecessary conversion to floating point
  * Counts and offsets for the MPI_Alltoallv call are ints, which could overflow

Overflow is probably unlikely given that the send counts are limited to 1024*1024, but we have a large count alltoallv implementation in the code already so there's no reason not to use that and use HBTInt for the counts and offsets.

I've also added unit tests for the alltoallv operations.