### PR TITLE
Add more detailed output in timing.log

### DIFF
--- a/HBT.cpp
+++ b/HBT.cpp
@@ -71,7 +71,7 @@ int main(int argc, char **argv)
   /* Main loop, iterate over chosen data outputs */
   for (int isnap = snapshot_start; isnap <= snapshot_end; isnap++)
   {
-    timer.Tick(world.Communicator);
+    timer.Tick("start", world.Communicator);
     ParticleSnapshot_t partsnap;
     partsnap.Load(world, isnap);
     subsnap.SetSnapshotIndex(isnap);
@@ -83,44 +83,46 @@ int main(int argc, char **argv)
     if ((isnap == snapshot_start) && (world.rank() == 0))
       HBTConfig.DumpParameters();
 
-    timer.Tick(world.Communicator);
+    timer.Tick("read_particles", world.Communicator);
     halosnap.UpdateParticles(world, partsnap);
-    timer.Tick(world.Communicator);
+    timer.Tick("update_halo_particles", world.Communicator);
     subsnap.UpdateParticles(world, partsnap);
     subsnap.UpdateMostBoundPosition(world, partsnap);
 
     // Don't need the particle data after this point, so save memory
     partsnap.ClearParticles();
 
-    timer.Tick(world.Communicator);
+    timer.Tick("update_subhalo_particles", world.Communicator);
     subsnap.AssignHosts(world, halosnap, partsnap);
     MergerTreeInfo merger_tree;
     merger_tree.StoreTracerIds(subsnap.Subhalos, HBTConfig.NumTracersForDescendants);
     subsnap.PrepareCentrals(world, halosnap);
 
-    timer.Tick(world.Communicator);
+    timer.Tick("assign_hosts", world.Communicator);
     if (world.rank() == 0)
       cout << "unbinding...\n";
     subsnap.RefineParticles();
 
-    timer.Tick(world.Communicator);
+    timer.Tick("unbind", world.Communicator);
     subsnap.MergeSubhalos();
 
-    timer.Tick(world.Communicator);
+    timer.Tick("merge", world.Communicator);
     subsnap.UpdateTracks(world, halosnap);
 
-    timer.Tick(world.Communicator);
+    timer.Tick("update_tracks", world.Communicator);
     merger_tree.FindDescendants(subsnap.Subhalos, world);
+
+    timer.Tick("merger_tree", world.Communicator);
     subsnap.Save(world);
 
-    timer.Tick(world.Communicator);
+    timer.Tick("write_subhalos", world.Communicator);
 
     /* Save measured timing information */
     if (world.rank() == 0)
     {
       time_log << isnap << "\t" << subsnap.GetSnapshotId();
       for (int i = 1; i < timer.Size(); i++)
-        time_log << "\t" << timer.GetSeconds(i);
+        time_log << "\t" << timer.names[i] << "=" << timer.GetSeconds(i);
       time_log << endl;
     }
     timer.Reset();

--- a/HBT.cpp
+++ b/HBT.cpp
@@ -91,7 +91,7 @@ int main(int argc, char **argv)
 
     halosnap.UpdateParticles(world, partsnap);
     global_timer.Tick("update_halo", world.Communicator);
-    
+
     subsnap.UpdateParticles(world, partsnap);
     subsnap.UpdateMostBoundPosition(world, partsnap);
     global_timer.Tick("update_subhalo", world.Communicator);

--- a/src/io/snapshot_io.cpp
+++ b/src/io/snapshot_io.cpp
@@ -51,9 +51,13 @@ void ParticleSnapshot_t::Load(MpiWorker_t &world, int snapshot_index, bool fill_
 
   ExchangeParticles(world);
 
+  global_timer.Tick("snapshot_exchange", world.Communicator);
+  
   if (fill_particle_hash)
     FillParticleHash();
 
+  global_timer.Tick("snapshot_hash", world.Communicator);
+  
   if (world.rank() == 0)
     cout << NumberOfParticlesOnAllNodes << " particles loaded at Snapshot " << snapshot_index << "(" << SnapshotId
          << ")" << endl;

--- a/src/io/snapshot_io.cpp
+++ b/src/io/snapshot_io.cpp
@@ -51,12 +51,12 @@ void ParticleSnapshot_t::Load(MpiWorker_t &world, int snapshot_index, bool fill_
 
   ExchangeParticles(world);
 
-  global_timer.Tick("snapshot_exchange", world.Communicator);
+  global_timer.Tick("snap_exchange", world.Communicator);
   
   if (fill_particle_hash)
     FillParticleHash();
 
-  global_timer.Tick("snapshot_hash", world.Communicator);
+  global_timer.Tick("snap_hash", world.Communicator);
   
   if (world.rank() == 0)
     cout << NumberOfParticlesOnAllNodes << " particles loaded at Snapshot " << snapshot_index << "(" << SnapshotId

--- a/src/io/snapshot_io.cpp
+++ b/src/io/snapshot_io.cpp
@@ -52,12 +52,12 @@ void ParticleSnapshot_t::Load(MpiWorker_t &world, int snapshot_index, bool fill_
   ExchangeParticles(world);
 
   global_timer.Tick("snap_exchange", world.Communicator);
-  
+
   if (fill_particle_hash)
     FillParticleHash();
 
   global_timer.Tick("snap_hash", world.Communicator);
-  
+
   if (world.rank() == 0)
     cout << NumberOfParticlesOnAllNodes << " particles loaded at Snapshot " << snapshot_index << "(" << SnapshotId
          << ")" << endl;

--- a/src/io/swiftsim_io.cpp
+++ b/src/io/swiftsim_io.cpp
@@ -19,7 +19,6 @@ using namespace std;
 #include "swiftsim_io.h"
 #include "exchange_and_merge.h"
 
-
 void create_SwiftSimHeader_MPI_type(MPI_Datatype &dtype)
 {
   /*to create the struct data type for communication*/
@@ -769,7 +768,7 @@ void SwiftSimReader_t::LoadSnapshot(MpiWorker_t &world, int snapshotId, vector<P
   assert(reads_done == 1);
 
   global_timer.Tick("snap_io", world.Communicator);
-  
+
   // #define SNAPSHOT_IO_TEST
 #ifdef SNAPSHOT_IO_TEST
   // For testing: dump the snapshot to a new set of files
@@ -1028,7 +1027,7 @@ void SwiftSimReader_t::LoadGroups(MpiWorker_t &world, int snapshotId, vector<Hal
   ExchangeAndMerge(world, Halos);
 
   global_timer.Tick("halo_comms", world.Communicator);
-  
+
   HBTConfig.GroupLoadedFullParticle = true;
 }
 

--- a/src/io/swiftsim_io.cpp
+++ b/src/io/swiftsim_io.cpp
@@ -19,6 +19,7 @@ using namespace std;
 #include "swiftsim_io.h"
 #include "exchange_and_merge.h"
 
+
 void create_SwiftSimHeader_MPI_type(MPI_Datatype &dtype)
 {
   /*to create the struct data type for communication*/
@@ -745,6 +746,8 @@ void SwiftSimReader_t::LoadSnapshot(MpiWorker_t &world, int snapshotId, vector<P
   // Every rank should have executed the reading code exactly once
   assert(reads_done == 1);
 
+  global_timer.Tick("snap_io", world.Communicator);
+  
   // #define SNAPSHOT_IO_TEST
 #ifdef SNAPSHOT_IO_TEST
   // For testing: dump the snapshot to a new set of files
@@ -890,6 +893,8 @@ void SwiftSimReader_t::LoadGroups(MpiWorker_t &world, int snapshotId, vector<Hal
 
   // Every rank should have executed the reading code exactly once
   assert(reads_done == 1);
+
+  global_timer.Tick("halo_io", world.Communicator);
 
   // #define HALO_IO_TEST
 #ifdef HALO_IO_TEST

--- a/src/io/swiftsim_io.cpp
+++ b/src/io/swiftsim_io.cpp
@@ -1005,6 +1005,8 @@ void SwiftSimReader_t::LoadGroups(MpiWorker_t &world, int snapshotId, vector<Hal
 
   ExchangeAndMerge(world, Halos);
 
+  global_timer.Tick("halo_comms", world.Communicator);
+  
   HBTConfig.GroupLoadedFullParticle = true;
 }
 

--- a/src/mymath.cpp
+++ b/src/mymath.cpp
@@ -4,6 +4,8 @@
 
 #include "mymath.h"
 
+Timer_t global_timer;
+
 int GetGrid(HBTReal x, HBTReal step, int dim)
 {
   int i = floor(x / step);

--- a/src/mymath.h
+++ b/src/mymath.h
@@ -114,6 +114,8 @@ public:
   }
 };
 
+extern Timer_t global_timer;
+
 #define myfopen(filepointer, filename, filemode)                                                                       \
   if (!((filepointer) = fopen(filename, filemode)))                                                                    \
   {                                                                                                                    \

--- a/src/mymath.h
+++ b/src/mymath.h
@@ -65,23 +65,26 @@ class Timer_t
 {
 public:
   vector<chrono::high_resolution_clock::time_point> tickers;
+  vector<string> names;
   Timer_t()
   {
     tickers.reserve(20);
   }
-  void Tick()
+  void Tick(string name)
   {
     tickers.push_back(chrono::high_resolution_clock::now());
+    names.push_back(name);
   }
-  void Tick(MPI_Comm comm)
+  void Tick(string name, MPI_Comm comm)
   // synchronized tick. wait for all processes to tick together.
   {
     MPI_Barrier(comm);
-    Tick();
+    Tick(name);
   }
   void Reset()
   {
     tickers.clear();
+    names.clear();
   }
   size_t Size()
   {


### PR DESCRIPTION
Here's the code I've been using to investigate perfomance of #24. It adds names to the timings in timing.log and separates out the time for I/O and time taken to rearrange the particles after reading them. The timer object is changed to a global variable so that it can be called from the read routines instead of just the top level program.