### PR TITLE
Zero out internal energy for non-gas particles

### DIFF
--- a/src/io/swiftsim_io.cpp
+++ b/src/io/swiftsim_io.cpp
@@ -425,6 +425,10 @@ void SwiftSimReader_t::ReadSnapshot(int ifile, Particle_t *ParticlesInFile, HBTI
         for (hsize_t i = 0; i < count; i += 1)
           ParticlesToRead[offset + i].InternalEnergy = u[i] * Header.energy_conversion * pow(Header.ScaleFactor, aexp);
       }
+    } else {
+      // Zero out internal energy for non-gas particles
+      for (hsize_t offset = 0; offset < read_count; offset += 1)
+        ParticlesToRead[offset].InternalEnergy = 0.0;
     }
 #endif
     { // type


### PR DESCRIPTION
In Unbind() the internal energy of each particle is accumulated regardless of type, but the Swift I/O code leaves it uninitialized for non-gas particles. This shows up as "Conditional jump or move depends on uninitialised value(s)" errors in valgrind and presumably causes incorrect output.

This PR sets the internal energy to zero for non-gas particles.