### PR TITLE
Save radius containing all particles

### DIFF
--- a/src/io/subhalo_io.cpp
+++ b/src/io/subhalo_io.cpp
@@ -48,7 +48,7 @@ void SubhaloSnapshot_t::BuildHDFDataType()
   InsertMember(VmaxPhysical, H5T_NATIVE_FLOAT);
   InsertMember(LastMaxVmaxPhysical, H5T_NATIVE_FLOAT);
   InsertMember(SnapshotIndexOfLastMaxVmax, H5T_NATIVE_INT);
-  InsertMember(R2SigmaComoving, H5T_NATIVE_FLOAT);
+  InsertMember(REncloseComoving, H5T_NATIVE_FLOAT);
   InsertMember(RHalfComoving, H5T_NATIVE_FLOAT);
   InsertMember(BoundR200CritComoving, H5T_NATIVE_FLOAT);
   //   InsertMember(R200MeanComoving, H5T_NATIVE_FLOAT);
@@ -59,8 +59,6 @@ void SubhaloSnapshot_t::BuildHDFDataType()
   InsertMember(SpecificSelfPotentialEnergy, H5T_NATIVE_FLOAT);
   InsertMember(SpecificSelfKineticEnergy, H5T_NATIVE_FLOAT);
   InsertMember(SpecificAngularMomentum, H5T_FloatVec3);
-//   InsertMember(SpinPeebles, H5T_FloatVec3);
-//   InsertMember(SpinBullock, H5T_FloatVec3);
 #ifdef HAS_GSL
   dims[0] = 3;
   dims[1] = 3;

--- a/src/subhalo.cpp
+++ b/src/subhalo.cpp
@@ -164,7 +164,7 @@ void SubhaloSnapshot_t::BuildMPIDataType()
   RegisterAttr(VmaxPhysical, MPI_FLOAT, 1);
   RegisterAttr(LastMaxVmaxPhysical, MPI_FLOAT, 1);
   RegisterAttr(SnapshotIndexOfLastMaxVmax, MPI_INT, 1);
-  RegisterAttr(R2SigmaComoving, MPI_FLOAT, 1);
+  RegisterAttr(REncloseComoving, MPI_FLOAT, 1);
   RegisterAttr(RHalfComoving, MPI_FLOAT, 1);
   RegisterAttr(BoundR200CritComoving, MPI_FLOAT, 1);
   // RegisterAttr(R200MeanComoving, MPI_FLOAT, 1);
@@ -175,8 +175,6 @@ void SubhaloSnapshot_t::BuildMPIDataType()
   RegisterAttr(SpecificSelfPotentialEnergy, MPI_FLOAT, 1);
   RegisterAttr(SpecificSelfKineticEnergy, MPI_FLOAT, 1);
   RegisterAttr(SpecificAngularMomentum[0], MPI_FLOAT, 3);
-// RegisterAttr(SpinPeebles[0], MPI_FLOAT, 3);
-// RegisterAttr(SpinBullock[0], MPI_FLOAT, 3);
 #ifdef HAS_GSL
   RegisterAttr(InertialEigenVector[0], MPI_FLOAT, 9);
   RegisterAttr(InertialEigenVectorWeighted[0], MPI_FLOAT, 9);
@@ -274,7 +272,7 @@ void Subhalo_t::CalculateProfileProperties(const Snapshot_t &epoch)
   HBTReal LastMaxVmax;
   HBTInt SnapshotIndexOfLastMaxVmax; //the snapshot when it has the maximum Vmax, only considering past snapshots.
 
-  HBTReal R2SigmaComoving;
+  HBTReal REncloseComoving;
   HBTReal RHalfComoving;
 
   HBTReal R200CritComoving;
@@ -288,7 +286,7 @@ void Subhalo_t::CalculateProfileProperties(const Snapshot_t &epoch)
   {
     RmaxComoving = 0.;
     VmaxPhysical = 0.;
-    R2SigmaComoving = 0.;
+    REncloseComoving = 0.;
     RHalfComoving = 0.;
     BoundR200CritComoving = 0.;
     // 	R200MeanComoving=0.;
@@ -296,13 +294,6 @@ void Subhalo_t::CalculateProfileProperties(const Snapshot_t &epoch)
     BoundM200Crit = 0.;
     // 	M200Mean=0.;
     // 	MVir=0.;
-    /*
-    for(int i=0;i<3;i++)
-    {
-      SpinPeebles[i]=0.;
-      SpinBullock[i]=0.;
-    }
-    */
     return;
   }
   HBTReal VelocityUnit = PhysicalConst::G / epoch.Cosmology.ScaleFactor;
@@ -337,7 +328,7 @@ void Subhalo_t::CalculateProfileProperties(const Snapshot_t &epoch)
   RmaxComoving = maxprof->r;
   VmaxPhysical = sqrt(maxprof->v * VelocityUnit);
   RHalfComoving = prof[Nbound / 2].r;
-  R2SigmaComoving = prof[(HBTInt)(Nbound * 0.955)].r;
+  REncloseComoving = prof[Nbound-1].r;
 
   HBTReal virialF_tophat, virialF_b200, virialF_c200;
   epoch.HaloVirialFactors(virialF_tophat, virialF_b200, virialF_c200);
@@ -351,15 +342,6 @@ void Subhalo_t::CalculateProfileProperties(const Snapshot_t &epoch)
     LastMaxVmaxPhysical = VmaxPhysical;
   }
 
-  /*the spin parameters are kind of ambiguous. do not provide*/
-  /*
-  for(int i=0;i<3;i++)
-  {
-    SpinPeebles[i]=SpecificAngularMomentum[i]*
-      sqrt(fabs(SpecificSelfPotentialEnergy+0.5*SpecificSelfKineticEnergy))/PhysicalConst::G/Mbound;
-    SpinBullock[i]=SpecificAngularMomentum[i]/sqrt(2.*PhysicalConst::G*Mbound*R2SigmaComoving);
-  }
-  */
 }
 
 void Subhalo_t::CalculateShape()

--- a/src/subhalo.h
+++ b/src/subhalo.h
@@ -57,7 +57,7 @@ public:
   float LastMaxVmaxPhysical;
   int SnapshotIndexOfLastMaxVmax; // the snapshot when it has the maximum Vmax, only considering past snapshots.
 
-  float R2SigmaComoving; // 95.5% containment radius, close to tidal radius?
+  float REncloseComoving; // Radius of minimum sphere which contains all particles
   float RHalfComoving;
 
   // SO properties using subhalo particles alone, meant for quick and dirty calculations
@@ -74,8 +74,6 @@ public:
                                      // counting of mutual potential.
   float SpecificSelfKineticEnergy;   //<0.5*v^2>
   float SpecificAngularMomentum[3];  //<Rphysical x Vphysical>
-  //   float SpinPeebles[3];
-  //   float SpinBullock[3];
 
   // shapes
 #ifdef HAS_GSL

--- a/src/subhalo.h
+++ b/src/subhalo.h
@@ -57,7 +57,7 @@ public:
   float LastMaxVmaxPhysical;
   int SnapshotIndexOfLastMaxVmax; // the snapshot when it has the maximum Vmax, only considering past snapshots.
 
-  float REncloseComoving; // Radius of minimum sphere which contains all particles
+  float REncloseComoving; // Radius of minimum sphere which contains all bound particles
   float RHalfComoving;
 
   // SO properties using subhalo particles alone, meant for quick and dirty calculations


### PR DESCRIPTION
It would be useful for SOAP to know the radius of each subhalo, since we can then use that as the initial value of read_radius. I have repurposed the `R2SigmaComoving` property for this since it wasn't being used. I've also removed the commented out spin parameters, which were using `R2SigmaComoving`.