### PR TITLE
New masking step to remove duplicate particles

### DIFF
--- a/HBT.cpp
+++ b/HBT.cpp
@@ -107,7 +107,7 @@ int main(int argc, char **argv)
 
     /* Store the NumTracersForDescendants most bound particles of subhaloes
      * resolved in the previous output. These will be used after unbinding to
-     * determine which subhalo has accreted them. Need to do here since 
+     * determine which subhalo has accreted them. Need to do here since
      * AssignHosts will mask out some particles, and hence change the Particle
      * vector of subhaloes. */
     MergerTreeInfo merger_tree;
@@ -118,7 +118,7 @@ int main(int argc, char **argv)
      * associated to. Need to do after StoringTracerIds, since this step can lead
      * to the loss of some of the most bound tracer particles */
     subsnap.ConstrainToSingleHost(halosnap);
-    
+
     /* We decide which subhaloes are the central of each FOF group. Centrals are
      * assigned all the particles in the FOF that do not belong to secondary
      * subhaloes. */

--- a/HBT.cpp
+++ b/HBT.cpp
@@ -105,10 +105,17 @@ int main(int argc, char **argv)
 
     /* Store the NumTracersForDescendants most bound particles of subhaloes
      * resolved in the previous output. These will be used after unbinding to
-     * determine which subhalo has accreted them */
+     * determine which subhalo has accreted them. Need to do here since 
+     * AssignHosts will mask out some particles, and hence change the Particle
+     * vector of subhaloes. */
     MergerTreeInfo merger_tree;
     merger_tree.StoreTracerIds(subsnap.Subhalos, HBTConfig.NumTracersForDescendants);
 
+    /* We constrain particles to belong to FOF that hosts the subhalo they are
+     * associated to. Need to do after StoringTracerIds, since this step can lead
+     * to the loss of some of the most bound tracer particles */
+    subsnap.ConstrainToSingleHost(halosnap);
+    
     /* We decide which subhaloes are the central of each FOF group. Centrals are
      * assigned all the particles in the FOF that do not belong to secondary
      * subhaloes. */

--- a/HBT.cpp
+++ b/HBT.cpp
@@ -150,10 +150,6 @@ int main(int argc, char **argv)
     subsnap.Save(world);
     global_timer.Tick("write_subhalos", world.Communicator);
 
-    /* Clean up the source of subhaloes from duplicate particles */
-    subsnap.CleanTracks();
-    global_timer.Tick("clean_tracks", world.Communicator);
-
     /* Output timing information */
     if (world.rank() == 0)
     {

--- a/HBT.cpp
+++ b/HBT.cpp
@@ -99,13 +99,14 @@ int main(int argc, char **argv)
     // Don't need the particle data after this point, so save memory
     partsnap.ClearParticles();
 
-    /* Clean up the source subhaloes from duplicate particles. Need to do after
-     * writing bound files to not remove bound particles, and before nesting
-     * hierarchy is next modified in AssignHosts. Invalidates Nbound but leaves
-     * the MinNumTracerPartOfSub most bound tracer particles in place. */
+    /* Clean up the source subhaloes from duplicate particles originating from the
+     * previous snapshot. We need to do it here so that any removed bound particles
+     * contribute to the estimate of the subgroup CoM position and velocity (used in
+     * decide centrals). We do it before assign hosts since subhaloes can change FOF
+     * and ranks, making the masking difficult. */
     subsnap.CleanTracks();
     global_timer.Tick("clean_tracks", world.Communicator);
-    
+
     /* We assign a FOF host to every pre-existing subhalo. All particles belonging to a
      * secondary subhalo are constrained to be within the FOF assigned to the
      * subhalo they belong to. Constraint not applied if particles are fof-less.*/

--- a/HBT.cpp
+++ b/HBT.cpp
@@ -150,6 +150,10 @@ int main(int argc, char **argv)
     subsnap.Save(world);
     global_timer.Tick("write_subhalos", world.Communicator);
 
+    /* Clean up the source of subhaloes from duplicate particles */
+    subsnap.CleanTracks();
+    global_timer.Tick("clean_tracks", world.Communicator);
+
     /* Output timing information */
     if (world.rank() == 0)
     {

--- a/src/config_parser.h
+++ b/src/config_parser.h
@@ -96,7 +96,7 @@ public:
     MinNumPartOfSub = 20;
     MinNumTracerPartOfSub = 10;
     NumTracerHostFinding = MinNumTracerPartOfSub;
-    NumTracersForDescendants = 10;
+    NumTracersForDescendants = MinNumTracerPartOfSub;
     GroupParticleIdMask = 0;
     MassInMsunh = 1e10;
     LengthInMpch = 1;

--- a/src/io/subhalo_io.cpp
+++ b/src/io/subhalo_io.cpp
@@ -307,6 +307,11 @@ void SubhaloSnapshot_t::Save(MpiWorker_t &world)
 
   // Every rank should have executed the writing code exactly once
   assert(writes_done == 1);
+
+  /* Clean up the source of subhaloes from duplicate particles */
+  CleanTracks();
+  global_timer.Tick("clean_tracks", world.Communicator);
+
 }
 
 void SubhaloSnapshot_t::WriteFile(int iFile, int nfiles, HBTInt NumSubsAll)

--- a/src/io/subhalo_io.cpp
+++ b/src/io/subhalo_io.cpp
@@ -276,45 +276,76 @@ void SubhaloSnapshot_t::ReadFile(int iFile, const SubReaderDepth_t depth)
 
 void SubhaloSnapshot_t::Save(MpiWorker_t &world)
 {
+  /* Create folder where to save files */
+  string subdir = GetSubDir();
+  mkdir(subdir.c_str(), 0755);
 
-  // Decide how many ranks per node write simultaneously
+  /* Decide how many ranks per node write simultaneously */
   int nr_nodes = (world.size() / world.MaxNodeSize);
   int nr_writing = HBTConfig.MaxConcurrentIO / nr_nodes;
   if (nr_writing < 1)
     nr_writing = 1; // Always at least one per node
 
-  string subdir = GetSubDir();
-  mkdir(subdir.c_str(), 0755);
+  /* Subhalo properties and bound particle lists. */
+  WriteBoundFiles(world, nr_writing);
 
+  /* Clean up the source subhaloes from duplicate particles. Need to do after
+   * bound files to not remove bound particles, and before source so that 
+   * the cleaned subgroups are available if we restart. */
+  CleanTracks();
+
+  /* Particles associated to each subhalo. Used for debugging and restarting. */
+  WriteSourceFiles(world, nr_writing);
+
+  global_timer.Tick("clean_tracks", world.Communicator);
+}
+
+void SubhaloSnapshot_t::WriteBoundFiles(MpiWorker_t &world, const int &number_ranks_writing)
+{
+  /* Number of total subhalo entries */
   HBTInt NumSubsAll = 0, NumSubs = Subhalos.size();
   MPI_Allreduce(&NumSubs, &NumSubsAll, 1, MPI_HBT_INT, MPI_SUM, world.Communicator);
 
   if (world.rank() == 0)
-    cout << "saving " << NumSubsAll << " subhalos to " << subdir << endl;
+    cout << "saving " << NumSubsAll << " subhalos to " << GetSubDir() << endl;
 
-  // Allow a limited number of ranks per node to write simultaneously
+  /* Allow a limited number of ranks per node to write simultaneously */
   int writes_done = 0;
   for (int rank_within_node = 0; rank_within_node < world.MaxNodeSize; rank_within_node += 1)
   {
     if (rank_within_node == world.NodeRank)
     {
-      WriteFile(world.rank(), world.size(), NumSubsAll);
+      WriteBoundSubfile(world.rank(), world.size(), NumSubsAll);
       writes_done += 1;
     }
-    if (rank_within_node % nr_writing == nr_writing - 1)
+    if (rank_within_node % number_ranks_writing == number_ranks_writing - 1)
       MPI_Barrier(world.Communicator);
   }
 
-  // Every rank should have executed the writing code exactly once
+  /* Every rank should have executed the writing code exactly once */
   assert(writes_done == 1);
-
-  /* Clean up the source of subhaloes from duplicate particles */
-  CleanTracks();
-  global_timer.Tick("clean_tracks", world.Communicator);
-
 }
 
-void SubhaloSnapshot_t::WriteFile(int iFile, int nfiles, HBTInt NumSubsAll)
+void SubhaloSnapshot_t::WriteSourceFiles(MpiWorker_t &world, const int &number_ranks_writing)
+{
+  /* Allow a limited number of ranks per node to write simultaneously */
+  int writes_done = 0;
+  for (int rank_within_node = 0; rank_within_node < world.MaxNodeSize; rank_within_node += 1)
+  {
+    if (rank_within_node == world.NodeRank)
+    {
+      WriteSourceSubfile(world.rank(), world.size());
+      writes_done += 1;
+    }
+    if (rank_within_node % number_ranks_writing == number_ranks_writing - 1)
+      MPI_Barrier(world.Communicator);
+  }
+
+  /* Every rank should have executed the writing code exactly once */
+  assert(writes_done == 1);
+}
+
+void SubhaloSnapshot_t::WriteBoundSubfile(int iFile, int nfiles, HBTInt NumSubsAll)
 {
   /* Create file */
   string filename;
@@ -424,7 +455,7 @@ void SubhaloSnapshot_t::WriteFile(int iFile, int nfiles, HBTInt NumSubsAll)
     HBTInt offset = 0;
     for (HBTInt i = 0; i < Subhalos.size(); i++)
     {
-      vl[i].len = Subhalos[i].Nbound;
+      vl[i].len = Subhalos[i].Nbound; // Save bound particles
       vl[i].p = &IdBuffer[offset];
       offset += Subhalos[i].Particles.size();
       for (auto &&p : Subhalos[i].Particles)
@@ -436,15 +467,49 @@ void SubhaloSnapshot_t::WriteFile(int iFile, int nfiles, HBTInt NumSubsAll)
   writeHDFmatrix(file, Subhalos.data(), "Subhalos", ndim, dim_sub, H5T_SubhaloInMem, H5T_SubhaloInDisk);
 
   H5Fclose(file);
+}
 
+void SubhaloSnapshot_t::WriteSourceSubfile(int iFile, int nfiles)
+{
+  /* Create file */
+  string filename;
   GetSubFileName(filename, iFile, "Src");
-  //   cout<<"Saving "<<Subhalos.size()<<" subhaloes to "<<filename<<"..."<<endl;
-  file = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+  hid_t file = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+
+  /* Size definitions */
+  hsize_t ndim = 1, dim_atom[] = {1}, dim_sub[] = {Subhalos.size()};
+
   writeHDFmatrix(file, &SnapshotId, "SnapshotId", ndim, dim_atom, H5T_NATIVE_INT);
-  for (HBTInt i = 0; i < vl.size(); i++)
-    vl[i].len = Subhalos[i].Particles.size();
+  
+#ifdef UNSIGNED_LONG_ID_OUTPUT
+  hid_t H5T_HBTIntArr = H5Tvlen_create(
+    H5T_NATIVE_ULONG); // this does not affect anything inside the code, but the presentation in the hdf file
+#else
+  hid_t H5T_HBTIntArr = H5Tvlen_create(H5T_HBTInt);
+#endif
+
+  /* Create the particle vector arrays here, which is different to vl in the 
+   * WriteBoundSubfile, due to cleaning Particle vectors  */
+  vector<hvl_t> vl(Subhalos.size());
+  vector<HBTInt> IdBuffer;
+  {
+    HBTInt NumberOfParticles = 0;
+    for (HBTInt i = 0; i < Subhalos.size(); i++)
+      NumberOfParticles += Subhalos[i].Particles.size();
+    IdBuffer.reserve(NumberOfParticles);
+    HBTInt offset = 0;
+    for (HBTInt i = 0; i < Subhalos.size(); i++)
+    {
+      vl[i].len = Subhalos[i].Particles.size(); // Save all particles
+      vl[i].p = &IdBuffer[offset];
+      offset += Subhalos[i].Particles.size();
+      for (auto &&p : Subhalos[i].Particles)
+        IdBuffer.push_back(p.Id);
+    }
+  }
+  
   writeHDFmatrix(file, vl.data(), "SrchaloParticles", ndim, dim_sub, H5T_HBTIntArr);
+
   H5Fclose(file);
   H5Tclose(H5T_HBTIntArr);
-  //   cout<<Subhalos.size()<<" subhaloes saved: "<<MemberTable.NBirth<<" birth, "<< MemberTable.NFake<<" fake.\n";
 }

--- a/src/io/subhalo_io.cpp
+++ b/src/io/subhalo_io.cpp
@@ -296,8 +296,6 @@ void SubhaloSnapshot_t::Save(MpiWorker_t &world)
 
   /* Particles associated to each subhalo. Used for debugging and restarting. */
   WriteSourceFiles(world, nr_writing);
-
-  global_timer.Tick("clean_tracks", world.Communicator);
 }
 
 void SubhaloSnapshot_t::WriteBoundFiles(MpiWorker_t &world, const int &number_ranks_writing)

--- a/src/io/subhalo_io.cpp
+++ b/src/io/subhalo_io.cpp
@@ -290,7 +290,7 @@ void SubhaloSnapshot_t::Save(MpiWorker_t &world)
   WriteBoundFiles(world, nr_writing);
 
   /* Clean up the source subhaloes from duplicate particles. Need to do after
-   * bound files to not remove bound particles, and before source so that 
+   * bound files to not remove bound particles, and before source so that
    * the cleaned subgroups are available if we restart. */
   CleanTracks();
 
@@ -478,7 +478,7 @@ void SubhaloSnapshot_t::WriteSourceSubfile(int iFile, int nfiles)
   hsize_t ndim = 1, dim_atom[] = {1}, dim_sub[] = {Subhalos.size()};
 
   writeHDFmatrix(file, &SnapshotId, "SnapshotId", ndim, dim_atom, H5T_NATIVE_INT);
-  
+
 #ifdef UNSIGNED_LONG_ID_OUTPUT
   hid_t H5T_HBTIntArr = H5Tvlen_create(
     H5T_NATIVE_ULONG); // this does not affect anything inside the code, but the presentation in the hdf file
@@ -486,7 +486,7 @@ void SubhaloSnapshot_t::WriteSourceSubfile(int iFile, int nfiles)
   hid_t H5T_HBTIntArr = H5Tvlen_create(H5T_HBTInt);
 #endif
 
-  /* Create the particle vector arrays here, which is different to vl in the 
+  /* Create the particle vector arrays here, which is different to vl in the
    * WriteBoundSubfile, due to cleaning Particle vectors  */
   vector<hvl_t> vl(Subhalos.size());
   vector<HBTInt> IdBuffer;
@@ -505,7 +505,7 @@ void SubhaloSnapshot_t::WriteSourceSubfile(int iFile, int nfiles)
         IdBuffer.push_back(p.Id);
     }
   }
-  
+
   writeHDFmatrix(file, vl.data(), "SrchaloParticles", ndim, dim_sub, H5T_HBTIntArr);
 
   H5Fclose(file);

--- a/src/io/swiftsim_io.cpp
+++ b/src/io/swiftsim_io.cpp
@@ -425,7 +425,9 @@ void SwiftSimReader_t::ReadSnapshot(int ifile, Particle_t *ParticlesInFile, HBTI
         for (hsize_t i = 0; i < count; i += 1)
           ParticlesToRead[offset + i].InternalEnergy = u[i] * Header.energy_conversion * pow(Header.ScaleFactor, aexp);
       }
-    } else {
+    }
+    else
+    {
       // Zero out internal energy for non-gas particles
       for (hsize_t offset = 0; offset < read_count; offset += 1)
         ParticlesToRead[offset].InternalEnergy = 0.0;

--- a/src/subhalo.cpp
+++ b/src/subhalo.cpp
@@ -246,9 +246,6 @@ void Subhalo_t::AverageCoordinates()
     copyHBTxyz(ComovingMostBoundPosition, Particles[GetTracerIndex()].ComovingPosition);
     copyHBTxyz(PhysicalMostBoundVelocity, Particles[GetTracerIndex()].GetPhysicalVelocity());
 
-    /* Copy the mass, in case this object becomes an orphan in the current output. */
-    Mbound = Particles[GetTracerIndex()].Mass;
-
     AveragePosition(ComovingAveragePosition, Particles.data(), Nbound);
     AverageVelocity(PhysicalAverageVelocity, Particles.data(), Nbound);
   }
@@ -542,10 +539,10 @@ HBTInt Subhalo_t::KickNullParticles()
 #endif
 }
 
-void Subhalo_t::CountParticles()
-/*update Nbound, Mbound, NboundType, MboundType *
+/*update Mbound, NboundType, MboundType *
  * this function is called during unbinding, merger and BH consumption(UpdateParticles)*
  */
+void Subhalo_t::CountParticles()
 {
 #ifdef DM_ONLY
   Mbound = 0.;

--- a/src/subhalo.cpp
+++ b/src/subhalo.cpp
@@ -328,7 +328,7 @@ void Subhalo_t::CalculateProfileProperties(const Snapshot_t &epoch)
   RmaxComoving = maxprof->r;
   VmaxPhysical = sqrt(maxprof->v * VelocityUnit);
   RHalfComoving = prof[Nbound / 2].r;
-  REncloseComoving = prof[Nbound-1].r;
+  REncloseComoving = prof[Nbound - 1].r;
 
   HBTReal virialF_tophat, virialF_b200, virialF_c200;
   epoch.HaloVirialFactors(virialF_tophat, virialF_b200, virialF_c200);
@@ -341,7 +341,6 @@ void Subhalo_t::CalculateProfileProperties(const Snapshot_t &epoch)
     SnapshotIndexOfLastMaxVmax = epoch.GetSnapshotIndex();
     LastMaxVmaxPhysical = VmaxPhysical;
   }
-
 }
 
 void Subhalo_t::CalculateShape()

--- a/src/subhalo.h
+++ b/src/subhalo.h
@@ -312,6 +312,8 @@ public:
   void PrepareCentrals(MpiWorker_t &world, HaloSnapshot_t &halo_snap);
   void RefineParticles();
   void UpdateTracks(MpiWorker_t &world, const HaloSnapshot_t &halo_snap);
+
+  /* To remove duplicate particles from the source subgroup after saving. */
   void CleanTracks();
 
   HBTInt size() const

--- a/src/subhalo.h
+++ b/src/subhalo.h
@@ -258,8 +258,14 @@ private:
   void BuildHDFDataType();
   void BuildMPIDataType();
   void PurgeMostBoundParticles();
+
+  /* I/O methods */
   void ReadFile(int iFile, const SubReaderDepth_t depth);
-  void WriteFile(int iFile, int nfiles, HBTInt NumSubsAll);
+  void WriteBoundFiles(MpiWorker_t &world, const int &number_ranks_writing);
+  void WriteSourceFiles(MpiWorker_t &world, const int &number_ranks_writing);
+  void WriteBoundSubfile(int iFile, int nfiles, HBTInt NumSubsAll);
+  void WriteSourceSubfile(int iFile, int nfiles);
+
   void LevelUpDetachedSubhalos();
   void ExtendCentralNest();
   void LocalizeNestedIds(MpiWorker_t &world);

--- a/src/subhalo.h
+++ b/src/subhalo.h
@@ -319,7 +319,7 @@ public:
   void RefineParticles();
   void UpdateTracks(MpiWorker_t &world, const HaloSnapshot_t &halo_snap);
 
-  /* To remove duplicate particles from the source subgroup after saving. */
+  /* To remove duplicate particles from the source subgroup. */
   void CleanTracks();
 
   HBTInt size() const

--- a/src/subhalo.h
+++ b/src/subhalo.h
@@ -312,6 +312,7 @@ public:
   void PrepareCentrals(MpiWorker_t &world, HaloSnapshot_t &halo_snap);
   void RefineParticles();
   void UpdateTracks(MpiWorker_t &world, const HaloSnapshot_t &halo_snap);
+  void CleanTracks();
 
   HBTInt size() const
   {

--- a/src/subhalo_merge.cpp
+++ b/src/subhalo_merge.cpp
@@ -187,24 +187,24 @@ void Subhalo_t::MergeTo(Subhalo_t &host)
   HBTInt np_max = host.Particles.size() + Nbound;
 
   /* TODO: check whether this exclusivity list is required. If everything is
-   * working as expected, we should have no duplicates between these two 
+   * working as expected, we should have no duplicates between these two
    * subhaloes*/
   unordered_set<HBTInt> UniqueIds(np_max);
   for (auto &&p : host.Particles)
     UniqueIds.insert(p.Id);
   host.Particles.reserve(np_max);
 
-  for(HBTInt i = 0; i < Nbound; i++)
+  for (HBTInt i = 0; i < Nbound; i++)
   {
     auto inserted = UniqueIds.insert(Particles[i].Id).second;
-    assert(inserted); // We should have no duplicates, hence we should always insert. 
+    assert(inserted); // We should have no duplicates, hence we should always insert.
 
     if (inserted)
       host.Particles.push_back(Particles[i]);
   }
 
   /* NOTE: commented out since host.Nbound does not necessarily increment by
-   * the number of accreted particles. TODO: does commenting this out break 
+   * the number of accreted particles. TODO: does commenting this out break
    * anything? I do not expect it to, since we are to unbinding the host after
    * merging checks */
   // host.Nbound += Nbound;

--- a/src/subhalo_merge.cpp
+++ b/src/subhalo_merge.cpp
@@ -215,7 +215,6 @@ void Subhalo_t::MergeTo(Subhalo_t &host)
    * to do it here, since the MostBoundPosition and MostBoundVelocity of tracks
    * are based on the ACTUAL MOST BOUND PARTICLE. Orphans are based on the
    * MOST BOUND TRACER PARTICLE. */
-  Mbound = Particles[GetTracerIndex()].Mass;
   MostBoundParticleId = Particles[GetTracerIndex()].Id;
   copyHBTxyz(ComovingMostBoundPosition, Particles[GetTracerIndex()].ComovingPosition);
   copyHBTxyz(PhysicalMostBoundVelocity, Particles[GetTracerIndex()].GetPhysicalVelocity());
@@ -227,5 +226,7 @@ void Subhalo_t::MergeTo(Subhalo_t &host)
    * subhalo has been done. */
   Nbound = 0;
   Particles.resize(0);
+
+  /* This function call will set all Mass and Nbound fields (including types) equal to zero */
   CountParticles();
 }

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -1149,7 +1149,6 @@ public:
          * to top masking step. */
         std::swap(subhalo.Particles[i], subhalo.Particles[tracer_counter++]); 
       }
-
     }
 
     /* Each resolved subhalo should contain at least this number of tracers 
@@ -1169,7 +1168,7 @@ public:
     /* At this point, we have navigated towards the bottom of the hierarchy.
      * Start masking bottom up. The iterators start after the last tracer we 
      * shifted is. */
-    auto it_begin = subhalo.Particles.begin() + tracer_counter, it_save = it_begin + tracer_counter;
+    auto it_begin = subhalo.Particles.begin() + tracer_counter, it_save = it_begin;
     for (auto it = it_begin; it != subhalo.Particles.end(); ++it)
     {
       auto insert_status = ExclusionList.insert(it->Id);

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -1214,7 +1214,8 @@ void SubhaloSnapshot_t::CleanTracks()
   for (HBTInt i = 0; i < MemberTable.SubGroups.size(); i++)
   {    
     auto &Group = MemberTable.SubGroups[i];
-    if (Group.size() == 0)
+
+    if (Group.size() <= 1)
       continue;
 
     auto &central = Subhalos[Group[0]];

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -1154,7 +1154,8 @@ public:
 
     /* Each resolved subhalo should contain at least this number of tracers 
      * bound to it, hence we should have found a sufficient number. */
-    assert(tracer_counter == HBTConfig.MinNumTracerPartOfSub);
+    if(subhalo.Nbound > 0)
+      assert(tracer_counter == HBTConfig.MinNumTracerPartOfSub);
     
     /* Update TracerIndex value */
     subhalo.SetTracerIndex(0); 

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -1208,6 +1208,9 @@ public:
      * subhaloes in the same FOF. This will prevent duplicates if the subhaloes
      * diverge in the next output*/
     subhalo.Particles.resize(it_save - subhalo.Particles.begin());
+
+    /* This is being updated for consistency, but having an updated Nbound is 
+     * not a requirement within the code until after Unbinding the next output. */
     subhalo.Nbound -= NboundChange;
   }
 };

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -1135,7 +1135,7 @@ public:
 
   void CleanSource(HBTInt subid, vector<Subhalo_t> &Subhalos, const MappedIndexTable_t<HBTInt, HBTInt> &TrackHash)
   {
-    /* Mask the 10 most bound tracer particles of every resolved subhalo in the 
+    /* Mask the 10 most bound tracer particles of every resolved subhalo in the
      * tree. We do this to not encounter issues during host finding. */
     MaskTopBottom(subid, Subhalos, TrackHash);
 
@@ -1187,8 +1187,8 @@ public:
       assert(tracer_counter == HBTConfig.MinNumTracerPartOfSub);
       /* At this stage, we should have have all tracers at the MinNumTracerPartOfSub
        * most bound particles */
-    
-      for(int i = 0; i < HBTConfig.MinNumTracerPartOfSub; i++)
+
+      for (int i = 0; i < HBTConfig.MinNumTracerPartOfSub; i++)
         assert(subhalo.Particles[i].IsTracer());
     }
 #endif
@@ -1201,7 +1201,7 @@ public:
       MaskTopBottom(TrackHash.GetIndex(nestedid), Subhalos, TrackHash);
   }
 
-  /* This routine masks particles by giving priority to subhaloes deeper 
+  /* This routine masks particles by giving priority to subhaloes deeper
    * in the hierarchy. */
   void MaskBottomTop(HBTInt subid, vector<Subhalo_t> &Subhalos, const MappedIndexTable_t<HBTInt, HBTInt> &TrackHash)
   {
@@ -1213,12 +1213,12 @@ public:
 
     /* Skip orphans */
     if (subhalo.Nbound <= 1)
-       return;
+      return;
 
 #ifndef NDEBUG
     /* At this stage, we should have have all tracers at the MinNumTracerPartOfSub
      * most bound particles */
-    for(int i = 0; i < HBTConfig.MinNumTracerPartOfSub; i++)
+    for (int i = 0; i < HBTConfig.MinNumTracerPartOfSub; i++)
       assert(subhalo.Particles[i].IsTracer());
 #endif
 
@@ -1245,13 +1245,13 @@ public:
 
     /* Resize to achieve a clean source subhalo, i.e. no duplicate IDs across
      * subhaloes in the same FOF. This will prevent duplicates if the subhaloes
-     * diverge in the next output. In this step we may remove enough particles 
+     * diverge in the next output. In this step we may remove enough particles
      * to make Nbound < MinNumPartOfSub, but the decision about its disruption is
      * made in the next output (e.g. it may reaccrete particles during unbinding) */
     subhalo.Particles.resize(it_save - subhalo.Particles.begin());
-   
+
     /* We should not be checking whether the subhalo keeps all the particles, but rather
-     * whether it retains at least MinNumTracerPartOfSub tracers */ 
+     * whether it retains at least MinNumTracerPartOfSub tracers */
     assert(subhalo.Particles.size() >= HBTConfig.MinNumTracerPartOfSub);
 
     /* This is being updated for consistency, but having an updated Nbound is
@@ -1261,14 +1261,14 @@ public:
 #ifndef NDEBUG
     /* We should have retained at least 10 most bound tracers. */
     {
-        int remaining_tracers = 0; 
-        for(int i  = 0; i < subhalo.Nbound; i++)
-        {
-            remaining_tracers += subhalo.Particles[i].IsTracer() ? 1 : 0;
-            if(remaining_tracers >= HBTConfig.MinNumTracerPartOfSub)
-                break;
-        }
-        assert(remaining_tracers >= HBTConfig.MinNumTracerPartOfSub);
+      int remaining_tracers = 0;
+      for (int i = 0; i < subhalo.Nbound; i++)
+      {
+        remaining_tracers += subhalo.Particles[i].IsTracer() ? 1 : 0;
+        if (remaining_tracers >= HBTConfig.MinNumTracerPartOfSub)
+          break;
+      }
+      assert(remaining_tracers >= HBTConfig.MinNumTracerPartOfSub);
     }
 #endif
   }

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -1156,6 +1156,9 @@ public:
      * bound to it, hence we should have found a sufficient number. */
     assert(tracer_counter == HBTConfig.MinNumTracerPartOfSub);
     
+    /* Update TracerIndex value */
+    subhalo.SetTracerIndex(0); 
+
     /* We go deeper in the hierarchy*/
     // TODO: check whether the hierarchical pointers  are valid at this stage.
     for (auto nestedid :

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -1185,6 +1185,7 @@ public:
      * subhaloes in the same FOF. This will prevent duplicates if the subhaloes
      * diverge in the next output*/
     subhalo.Particles.resize(it_save - subhalo.Particles.begin());
+    subhalo.Nbound = subhalo.Particles.size(); // NOTE: Nbound no longer refers to number of bound particles
   }
 };
 

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -644,10 +644,6 @@ void SubhaloSnapshot_t::AssignHosts(MpiWorker_t &world, HaloSnapshot_t &halo_sna
   halo_snap.ClearParticleHash();
 
   MemberTable.Build(halo_snap.Halos.size(), Subhalos, true);
-
-  /* We constrain particles to belong to FOF that hosts the subhalo they are
-   * associated to. */
-  ConstrainToSingleHost(halo_snap);
 }
 
 /* Constrains subhaloes to only exist within a single host. This prevents

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -1162,8 +1162,27 @@ public:
          subhalo
            .NestedSubhalos)
       MaskTopBottom(nestedid, Subhalos);
-  }
 
+    /* At this point, we have navigated towards the bottom of the hierarchy.
+     * Start masking bottom up. The iterators start after the last tracer we 
+     * shifted is. */
+    auto it_begin = subhalo.Particles.begin() + tracer_counter, it_save = it_begin + tracer_counter;
+    for (auto it = it_begin; it != subhalo.Particles.end(); ++it)
+    {
+      auto insert_status = ExclusionList.insert(it->Id);
+      if (insert_status.second) // inserted, meaning not excluded
+      {
+        if (it != it_save)
+          *it_save = move(*it);
+        ++it_save;
+      }
+    }
+
+    /* Resize to achieve a clean source subhalo, i.e. no duplicate IDs across 
+     * subhaloes in the same FOF. This will prevent duplicates if the subhaloes
+     * diverge in the next output*/
+    subhalo.Particles.resize(it_save - subhalo.Particles.begin());
+  }
 };
 
 void SubhaloSnapshot_t::MaskSubhalos()

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -1307,9 +1307,9 @@ void SubhaloSnapshot_t::CleanTracks()
   {
     /* Skip non-centrals and centrals with no subhalos */
     auto &central = Subhalos[subid];
-    if((central.Rank != 0) || (central.NestedSubhalos.size() == 0))
+    if ((central.Rank != 0) || (central.NestedSubhalos.size() == 0))
       continue;
-      
+
     /* We need to use the TrackHash here, since the subids have been converted
      * to the global values. */
     SubhaloMasker_t Masker(central.Particles.size() * 1.2);

--- a/src/subhalo_unbind.cpp
+++ b/src/subhalo_unbind.cpp
@@ -410,8 +410,9 @@ void Subhalo_t::Unbind(const Snapshot_t &epoch)
 
       /* Do not allow the orphan to have any particles, so they can be subject to
        * unbinding in their parent. The particle array will be updated after this
-       * subhalo has been done. */
+       * subhalo has been done, when truncating the source. */
       Nbound = 0;
+      Mbound = 0;
 
       break;
     }
@@ -462,6 +463,9 @@ void Subhalo_t::Unbind(const Snapshot_t &epoch)
   }
   ESnap.AverageKinematics(SpecificSelfPotentialEnergy, SpecificSelfKineticEnergy, SpecificAngularMomentum, Nbound,
                           RefPos, RefVel); // only use CoM frame when unbinding and calculating Kinematics
+
+  /* For orphans, this function call only sets it MboundType and NboundType equal to 0. For resolved objects, it
+   * updates those fields, as well as the index of the most bound tracer particle.*/
   CountParticleTypes();
 
   /* At this stage we know the updated TracerIndex, so if we are bound we should


### PR DESCRIPTION
In HBT, particles that are unbound from their original subhalo are passed to the source subhalo of its parent. As the original subhalo also retains the particle, this leads to the same particle being across more than one source. This is not a problem if subhalos are in the same FOF, but if they are found in different hosts, we may find duplicate bound particles.

Fix #26 solved the case for particles that are found across FOF groups, but another special case leads to some duplications. This is when the troublesome particle is not part of a FOF group, since we are not applying the FOF exclusivity criteria to them.

To solve the issue, we believe we should update the sources of subhaloes (i.e. Particles vector) after saving the bound properties. By applying a masking step, we can assign particles to a single source subgroup, typically the deepest one in the hierarchy (unless the source subhalo has been truncated). 

To prevent the accidental removal of the 10 most bound tracer particles (important for tracers and boundness criteria) we first apply the masking on the 10 most bound tracers from top to bottom, and then on the remaining particles from bottom to top. 