### PR TITLE
Set OMP_NUM_THREADS when running unit tests

### DIFF
--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(testfuncs OBJECT
 #
 # First do tests which do not use MPI
 #
+set(HBT_TEST_OMP_NUM_THREADS 4 CACHE STRING "Set the number of OpenMP threads used in unit tests")
 foreach(TEST_NAME
     test_build_pos_vel
     test_argsort
@@ -33,14 +34,15 @@ foreach(TEST_NAME
   add_executable(${TEST_NAME} ${TEST_NAME}.cpp $<TARGET_OBJECTS:hbtfuncs> $<TARGET_OBJECTS:testfuncs>)
   target_link_libraries(${TEST_NAME} ${MPI_C_LIBRARIES} ${MPI_CXX_LIBRARIES} ${HDF5_C_LIBRARIES} ${HDF5_HL_LIBRARIES} ${GSL_LIBRARIES})
   add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
-
+  set_tests_properties(${TEST_NAME} PROPERTIES ENVIRONMENT OMP_NUM_THREADS=${HBT_TEST_OMP_NUM_THREADS})
+  
 endforeach()
 
 #
 # Then run unit tests which do require MPI
 # In this case we use the output from FindMPI to construct an mpiexec command.
 #
-set(HBT_MPI_TEST_NPROCS 4 CACHE STRING "Set the number of processors used in MPI unit tests")
+set(HBT_TEST_MPI_NPROCS 4 CACHE STRING "Set the number of MPI processes used in unit tests")
 foreach(TEST_NAME
     test_mpi
     test_exchange_counts
@@ -52,7 +54,8 @@ foreach(TEST_NAME
 
   add_executable(${TEST_NAME} ${TEST_NAME}.cpp $<TARGET_OBJECTS:hbtfuncs> $<TARGET_OBJECTS:testfuncs>)
   target_link_libraries(${TEST_NAME} ${MPI_C_LIBRARIES} ${MPI_CXX_LIBRARIES} ${HDF5_C_LIBRARIES} ${HDF5_HL_LIBRARIES} ${GSL_LIBRARIES})
-  add_test(NAME ${TEST_NAME} COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${HBT_MPI_TEST_NPROCS} ${MPIEXEC_PREFLAGS} ${TEST_NAME} ${MPIEXEC_POSTFLAGS})
+  add_test(NAME ${TEST_NAME} COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${HBT_TEST_MPI_NPROCS} ${MPIEXEC_PREFLAGS} ${TEST_NAME} ${MPIEXEC_POSTFLAGS})
+  set_tests_properties(${TEST_NAME} PROPERTIES ENVIRONMENT OMP_NUM_THREADS=${HBT_TEST_OMP_NUM_THREADS})
   
 endforeach()
 


### PR DESCRIPTION
This pull request adds a cmake variable with the number of threads to use in unit tests and makes it default to 4.

This helps because if OMP_NUM_THREADS is not set each MPI rank tries to use all of the available cores so the cores become oversubscribed and `make test` takes many minutes to complete.