### PR TITLE
Don't try to set particle type for debug check when compiling with DM_ONLY

### DIFF
--- a/src/io/subhalo_io.cpp
+++ b/src/io/subhalo_io.cpp
@@ -173,13 +173,16 @@ void SubhaloSnapshot_t::Load(MpiWorker_t &world, int snapshot_index, const SubRe
   }
 
 #ifndef NDEBUG
+#ifndef DM_ONLY
   // On restarting we don't know the particle types because only Ids were saved to the SrcSnap.
   // Set Type=TypeMax to avoid tripping assert due to tracer not found when updating particles.
+  // Don't need to do this in DM only runs.
   for(auto &sub : Subhalos) {
     for(auto &part : sub.Particles) {
       part.Type = TypeMax;
     }
   }
+#endif
 #endif
   
 }

--- a/src/io/subhalo_io.cpp
+++ b/src/io/subhalo_io.cpp
@@ -171,6 +171,17 @@ void SubhaloSnapshot_t::Load(MpiWorker_t &world, int snapshot_index, const SubRe
     }
     cout << TotNumberOfSubs << " subhalos loaded at snapshot " << SnapshotIndex << "(" << SnapshotId << ")\n";
   }
+
+#ifndef NDEBUG
+  // On restarting we don't know the particle types because only Ids were saved to the SrcSnap.
+  // Set Type=TypeMax to avoid tripping assert due to tracer not found when updating particles.
+  for(auto &sub : Subhalos) {
+    for(auto &part : sub.Particles) {
+      part.Type = TypeMax;
+    }
+  }
+#endif
+  
 }
 void SubhaloSnapshot_t::ReadFile(int iFile, const SubReaderDepth_t depth)
 { // Read iFile for current snapshot.

--- a/src/subhalo_update_mostbound.cpp
+++ b/src/subhalo_update_mostbound.cpp
@@ -45,7 +45,9 @@ void SubhaloSnapshot_t::UpdateMostBoundPosition(MpiWorker_t &world, const Partic
       // assert() if any tracer particle is not found. Here we set Type=TypeMax
       // to indicate that we don't know the particle type so it's ok if we
       // can't find it - it might have genuinely disappeared.
+#ifndef DM_ONLY
       ZeroSizeSubhalo[nr_zero].Particles[0].Type = TypeMax; // Particle type is not known
+#endif
 #endif
       for (int j = 0; j < 3; j += 1)
       {


### PR DESCRIPTION
This fixes a bug I introduced in #27 which prevents compilation in Debug mode with -DDM_ONLY enabled.