### PR TITLE
Execute new masking step just before AssignHosts()

### DIFF
--- a/src/io/subhalo_io.cpp
+++ b/src/io/subhalo_io.cpp
@@ -289,11 +289,6 @@ void SubhaloSnapshot_t::Save(MpiWorker_t &world)
   /* Subhalo properties and bound particle lists. */
   WriteBoundFiles(world, nr_writing);
 
-  /* Clean up the source subhaloes from duplicate particles. Need to do after
-   * bound files to not remove bound particles, and before source so that
-   * the cleaned subgroups are available if we restart. */
-  CleanTracks();
-
   /* Particles associated to each subhalo. Used for debugging and restarting. */
   WriteSourceFiles(world, nr_writing);
 }

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -1301,24 +1301,24 @@ void SubhaloSnapshot_t::CleanTracks()
   MappedIndexTable_t<HBTInt, HBTInt> TrackHash;
   TrackHash.Fill(Ids, SpecialConst::NullTrackId);
 
-  /* Iterate over all FOF groups in the present rank. */
+  /* Iterate over all subhalos in the present rank. */
 #pragma omp parallel for
-  for (HBTInt grpid = 0; grpid < MemberTable.SubGroups.size(); grpid++)
+  for (HBTInt subid = 0; subid < Subhalos.size(); subid++)
   {
-    auto &Group = MemberTable.SubGroups[grpid];
-    if (Group.size() <= 1)
+    /* Skip non-centrals and centrals with no subhalos */
+    auto &central = Subhalos[subid];
+    if((central.Rank != 0) || (central.NestedSubhalos.size() == 0))
       continue;
-
+      
     /* We need to use the TrackHash here, since the subids have been converted
      * to the global values. */
-    auto &central = Subhalos[Group[0]];
     SubhaloMasker_t Masker(central.Particles.size() * 1.2);
 
     // Try allocating sufficient memory for this to work
-    HBTInt MaskerSize = Masker.EstimateListSize(Group[0], Subhalos, TrackHash);
+    HBTInt MaskerSize = Masker.EstimateListSize(subid, Subhalos, TrackHash);
 
     Masker.ExclusionList.reserve(MaskerSize * 1.2);
-    Masker.CleanSource(Group[0], Subhalos, TrackHash);
+    Masker.CleanSource(subid, Subhalos, TrackHash);
   }
 }
 


### PR DESCRIPTION
In the new_masking_step branch Nbound is written to the SubSnap output and then modified before the SrcSnap is written. On restarting an out of date value is read from the SubSnap files and the code crashes because Nbound can be greater than the size of the reduced particle arrays read from the SrcSnap.

Here I've modified the code to execute the masking later. This solves the restarting problem because the SrcSnap and SubSnap are consistent.

There's another problem in that the extra masking step eliminates particles which we want to use to compute halo positions and velocities for use after AssignHosts() but still using Nbound from the previous snapshot. It might be necessary to move those calculations earlier in the code.