### PR TITLE
Avoid integer overflow setting SinkTrackId

### DIFF
--- a/src/subhalo.h
+++ b/src/subhalo.h
@@ -106,7 +106,7 @@ public:
   bool AreOverlappingInPhaseSpace(const Subhalo_t &ReferenceSubhalo);
   float PhaseSpaceDistance(const Subhalo_t &ReferenceSubhalo);
   void GetCorePhaseSpaceProperties();
-  void SetMergerInformation(const int &ReferenceTrackId, const int &SnapshotIndex);
+  void SetMergerInformation(const HBTInt &ReferenceTrackId, const int &SnapshotIndex);
 
   /* Properties relating to the new merging approach */
   HBTxyz CoreComovingPosition;

--- a/src/subhalo_merge.cpp
+++ b/src/subhalo_merge.cpp
@@ -27,7 +27,7 @@ bool Subhalo_t::AreOverlappingInPhaseSpace(const Subhalo_t &ReferenceSubhalo)
 }
 
 /* Store information about the merger that has just occured. */
-void Subhalo_t::SetMergerInformation(const int &ReferenceTrackId, const int &CurrentSnapshotIndex)
+void Subhalo_t::SetMergerInformation(const HBTInt &ReferenceTrackId, const int &CurrentSnapshotIndex)
 {
   /* When this occured */
   SnapshotIndexOfSink = CurrentSnapshotIndex;


### PR DESCRIPTION
On the FLAMINGO 10k run TrackIds exceed the maximum value of an int, and there's an instance in the code where SinkTrackId is stored as an int rather than a HBTInt so the value overflows.