### PR TITLE
Set units automatically from snapshot

### DIFF
--- a/src/io/swiftsim_io.cpp
+++ b/src/io/swiftsim_io.cpp
@@ -677,6 +677,11 @@ void SwiftSimReader_t::LoadSnapshot(MpiWorker_t &world, int snapshotId, vector<P
   HBTConfig.TreeNodeResolution = HBTConfig.SofteningHalo * 0.1;
   HBTConfig.TreeNodeResolutionHalf = HBTConfig.TreeNodeResolution / 2.;
 
+  /* Update the units */
+  HBTConfig.MassInMsunh = Header.MassInMsunh;
+  HBTConfig.LengthInMpch = Header.LengthInMpch;
+  HBTConfig.VelInKmS = Header.VelInKmS;
+
   /* This will be used to determine which particles are hostless when
    * constraining subhaloes to their assigned hosts. */
   HBTConfig.ParticleNullGroupId = Header.NullGroupId;

--- a/src/io/swiftsim_io.cpp
+++ b/src/io/swiftsim_io.cpp
@@ -682,6 +682,11 @@ void SwiftSimReader_t::LoadSnapshot(MpiWorker_t &world, int snapshotId, vector<P
   HBTConfig.LengthInMpch = Header.LengthInMpch;
   HBTConfig.VelInKmS = Header.VelInKmS;
 
+  /* Update the gravitational constant and H based on the units loaded from
+   * swift */
+  PhysicalConst::G = 43.0071 * (HBTConfig.MassInMsunh / 1e10) / HBTConfig.VelInKmS / HBTConfig.VelInKmS / HBTConfig.LengthInMpch;
+  PhysicalConst::H0 = 100. * (1. / HBTConfig.VelInKmS) / (1. / HBTConfig.LengthInMpch);
+
   /* This will be used to determine which particles are hostless when
    * constraining subhaloes to their assigned hosts. */
   HBTConfig.ParticleNullGroupId = Header.NullGroupId;

--- a/src/io/swiftsim_io.cpp
+++ b/src/io/swiftsim_io.cpp
@@ -48,6 +48,9 @@ void create_SwiftSimHeader_MPI_type(MPI_Datatype &dtype)
   RegisterAttr(h, MPI_DOUBLE, 1) RegisterAttr(mass, MPI_DOUBLE, TypeMax);
   RegisterAttr(npart[0], MPI_INT, TypeMax);
   RegisterAttr(npartTotal[0], MPI_HBT_INT, TypeMax);
+  RegisterAttr(MassInMsunh, MPI_DOUBLE, 1);
+  RegisterAttr(LengthInMpch, MPI_DOUBLE, 1);
+  RegisterAttr(VelInKmS, MPI_DOUBLE, 1);
   RegisterAttr(NullGroupId, MPI_HBT_INT, 1);
   RegisterAttr(DM_comoving_softening, MPI_DOUBLE, 1);
   RegisterAttr(DM_maximum_physical_softening, MPI_DOUBLE, 1);
@@ -165,6 +168,10 @@ void SwiftSimReader_t::ReadHeader(int ifile, SwiftSimHeader_t &header)
     throw std::overflow_error("The precision of HBTInt is insufficient to hold the value of NullGroupId");
   Header.NullGroupId = (HBTInt)NullGroupId;
 
+  /* Load the units used in the snapshot */
+  Header.MassInMsunh  = (mass_cgs / solar_mass_cgs) * Header.h;
+  Header.LengthInMpch = (length_cgs / (1.0e6 * parsec_cgs)) * Header.h;
+  Header.VelInKmS     = (length_cgs / time_cgs) / km_cgs;
 
   /*
      Read per-type header entries

--- a/src/io/swiftsim_io.h
+++ b/src/io/swiftsim_io.h
@@ -27,6 +27,9 @@ struct SwiftSimHeader_t
   double mass[TypeMax];
   int npart[TypeMax];
   HBTInt npartTotal[TypeMax];
+  double MassInMsunh;
+  double LengthInMpch;
+  double VelInKmS;
   HBTInt NullGroupId;
   double DM_comoving_softening;
   double DM_maximum_physical_softening;

--- a/src/io/swiftsim_io.h
+++ b/src/io/swiftsim_io.h
@@ -27,10 +27,6 @@ struct SwiftSimHeader_t
   double mass[TypeMax];
   int npart[TypeMax];
   HBTInt npartTotal[TypeMax];
-  double length_conversion;
-  double mass_conversion;
-  double velocity_conversion;
-  double energy_conversion;
   HBTInt NullGroupId;
   double DM_comoving_softening;
   double DM_maximum_physical_softening;


### PR DESCRIPTION
Previously, we would define the mass length and velocity units in the parameter file. We often opted for a value that removed the factors of `h` in the catalogues. This approach means that we need to keep track of which simulations change the value of `h`.

I have changed the units such that they are defined by those used in swift. This will be consistent to the approach we normally use, but is now fool-proof. 