### PR TITLE
Function to make traceless subhalos default to be hostless

### DIFF
--- a/src/subhalo.h
+++ b/src/subhalo.h
@@ -277,6 +277,8 @@ private:
   void FillDepth();
   void SetNestedParentIds();
 
+  void HandleTracerlessSubhalos(MpiWorker_t &world, vector<Subhalo_t> &LocalSubhalos);
+
 public:
   SubhaloList_t Subhalos;
   MemberShipTable_t MemberTable;

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -655,11 +655,40 @@ void SubhaloSnapshot_t::AssignHosts(MpiWorker_t &world, HaloSnapshot_t &halo_sna
   /* Those which require information from external ranks are dealt with here. */
   for (int rank = 0; rank < world.size(); rank++)
     FindOtherHostsSafely(world, rank, halo_snap, part_snap, Subhalos, LocalSubhalos, MPI_HBT_SubhaloShell_t);
+  
+  /* Here we will change the host halo ID of subhalos whose tracers were lost*/
+  HandleTracerlessSubhalos(world, LocalSubhalos);
 
   Subhalos.swap(LocalSubhalos);
   halo_snap.ClearParticleHash();
 
   MemberTable.Build(halo_snap.Halos.size(), Subhalos, true);
+}
+
+/* This function iterates over Subhalos and assigns a default HostHaloId (-1) to all Subhalos
+ * whose tracer particles were not found. If any such cases are present in the simulation, a 
+ * warning is printed. */
+void SubhaloSnapshot_t::HandleTracerlessSubhalos(MpiWorker_t &world, vector<Subhalo_t> &LocalSubhalos)
+{
+  HBTInt NumberTracerlessSubhalos = 0;
+
+#pragma omp parallel for reduction (+:NumberTracerlessSubhalos) if (LocalSubhalos.size() > 20)
+  for (HBTInt i = 0; i < LocalSubhalos.size(); i++)
+  {
+    if(LocalSubhalos[i].HostHaloId == -2) // Tracerless
+    {
+      LocalSubhalos[i].HostHaloId = -1; // Make them hostless
+      NumberTracerlessSubhalos++;
+    }
+  }
+
+  /* Determine if any subgroup in the simulation had missing tracers, and if so,
+   * print out a warning */
+  HBTInt GlobalNumberTracelessSubhalos = 0;
+  MPI_Allreduce(&NumberTracerlessSubhalos, &GlobalNumberTracelessSubhalos, 1, MPI_HBT_INT, MPI_SUM, world.Communicator);
+
+  if((GlobalNumberTracelessSubhalos > 0) && (world.rank() == 0))
+      std::cout << "WARNING: " << GlobalNumberTracelessSubhalos << " subhalos were missing their particle tracers." << std::endl;
 }
 
 /* Constrains subhaloes to only exist within a single host. This prevents

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -688,7 +688,7 @@ void SubhaloSnapshot_t::HandleTracerlessSubhalos(MpiWorker_t &world, vector<Subh
   MPI_Allreduce(&NumberTracerlessSubhalos, &GlobalNumberTracelessSubhalos, 1, MPI_HBT_INT, MPI_SUM, world.Communicator);
 
   if((GlobalNumberTracelessSubhalos > 0) && (world.rank() == 0))
-      std::cout << "WARNING: " << GlobalNumberTracelessSubhalos << " subhalos were missing their particle tracers. This is likely due to using particles that dissapear from the simulation (e.g. merging black holes) as subahalo tracers." << std::endl;
+      std::cout << "WARNING: " << GlobalNumberTracelessSubhalos << " subhalos were missing their particle tracers. This is likely due to using particles that dissapear from the simulation (e.g. merging black holes) as subhalo tracers." << std::endl;
 }
 
 /* Constrains subhaloes to only exist within a single host. This prevents

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -688,7 +688,7 @@ void SubhaloSnapshot_t::HandleTracerlessSubhalos(MpiWorker_t &world, vector<Subh
   MPI_Allreduce(&NumberTracerlessSubhalos, &GlobalNumberTracelessSubhalos, 1, MPI_HBT_INT, MPI_SUM, world.Communicator);
 
   if((GlobalNumberTracelessSubhalos > 0) && (world.rank() == 0))
-      std::cout << "WARNING: " << GlobalNumberTracelessSubhalos << " subhalos were missing their particle tracers." << std::endl;
+      std::cout << "WARNING: " << GlobalNumberTracelessSubhalos << " subhalos were missing their particle tracers. This is likely due to using particles that dissapear from the simulation (e.g. merging black holes) as subahalo tracers." << std::endl;
 }
 
 /* Constrains subhaloes to only exist within a single host. This prevents


### PR DESCRIPTION
This PR is intended to deal with #46. The current master branch is unable to handle cases where the tracers disappear from the simulation, e.g. gas or black holes in our example simulations.

Prior to our changes, HBT+ would be able to "handle" them by making them hostless by default. I have recovered this behaviour, but we now print a warning for the user to realise that their choice of tracers may be leading  to incorrect assignments of host halo IDs. They can ignore the warning if they really want to use their current tracer configuration.

The alternative is to keep the current inability to handle these cases, but it leads to memory errors due to trying to access an array out of its bounds.