### PR TITLE
Option to output particle binding energies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ cmake_install.cmake
 testing/build/
 testing/test_output/
 openmpi-5.0.3-hdf5-1.12.3-env
-build
+*build*

--- a/configs/Apostle_V1_HR.conf
+++ b/configs/Apostle_V1_HR.conf
@@ -25,4 +25,4 @@ MinNumPartOfSub 20
 #BoundMassPrecision 0.995
 #PeriodicBoundaryOn 1
 
-SaveSubParticleProperties 0
+SaveBoundParticleProperties 0

--- a/configs/COLIBRE_test.conf
+++ b/configs/COLIBRE_test.conf
@@ -35,5 +35,5 @@ MinNumTracerPartOfSub 10 # Minimum number of particles of types specified by Tra
 # Optional parameters; default values are shown here
 #BoundMassPrecision 0.995
 #PeriodicBoundaryOn 1
-#SaveSubParticleProperties 0
+#SaveBoundParticleProperties 0
 #TracerParticleTypes 1 4 

--- a/configs/EagleL100N1504.conf
+++ b/configs/EagleL100N1504.conf
@@ -25,6 +25,6 @@ MinNumPartOfSub 20
 #BoundMassPrecision 0.995
 #PeriodicBoundaryOn 1
 
-SaveSubParticleProperties 0
+SaveBoundParticleProperties 0
 
 MaxConcurrentIO 16                    #the maximum number of concurrent io processes

--- a/configs/Example.conf
+++ b/configs/Example.conf
@@ -33,7 +33,7 @@ SofteningHalo 5e-3                         #softening of dark matter particles
 
 #MinNumPartOfSub 20
 
-#SaveSubParticleProperties 0               #save position and velocity for each subhalo particle; set to 0 to disable.
+#SaveBoundParticleProperties 0               #save position and velocity for each subhalo particle; set to 0 to disable.
 
 [Performance]
 #MaxSampleSizeOfPotentialEstimate 1000     #the maximum number of particles to use when calculating potential for unbinding purpose. A value of 1000 should lead to percent level accuracy in bound mass. Larger values leads to more accurate unbinding, but would be slower. Set to 0 to use all particles available, i.e., to disable sampling and calculate binding energy precisely.

--- a/src/config_parser.cpp
+++ b/src/config_parser.cpp
@@ -54,6 +54,7 @@ bool Parameter_t::TrySingleValueParameter(string ParameterName, stringstream &Pa
   TrySetPar(ParticleIdNeedHash);
   TrySetPar(SnapshotIdUnsigned);
   TrySetPar(SaveSubParticleProperties);
+  TrySetPar(SaveParticleBindingEnergies);
   TrySetPar(MergeTrappedSubhalos);
   TrySetPar(MajorProgenitorMassRatio);
   TrySetPar(BoundMassPrecision);
@@ -294,6 +295,7 @@ void Parameter_t::BroadCast(MpiWorker_t &world, int root)
   _SyncBool(ParticleIdNeedHash);
   _SyncBool(SnapshotIdUnsigned);
   _SyncBool(SaveSubParticleProperties);
+  _SyncBool(SaveParticleBindingEnergies);
   _SyncBool(MergeTrappedSubhalos);
   _SyncVec(SnapshotIdList, MPI_INT);
   world.SyncVectorString(SnapshotNameList, root);
@@ -399,6 +401,7 @@ void Parameter_t::DumpParameters()
   DumpPar(ParticleIdNeedHash);
   DumpPar(SnapshotIdUnsigned);
   DumpPar(SaveSubParticleProperties);
+  DumpPar(SaveParticleBindingEnergies);
 #ifndef DM_ONLY
   DumpPar(ParticlesSplit);
 #endif

--- a/src/config_parser.cpp
+++ b/src/config_parser.cpp
@@ -53,8 +53,8 @@ bool Parameter_t::TrySingleValueParameter(string ParameterName, stringstream &Pa
   TrySetPar(ParticleIdRankStyle);
   TrySetPar(ParticleIdNeedHash);
   TrySetPar(SnapshotIdUnsigned);
-  TrySetPar(SaveSubParticleProperties);
-  TrySetPar(SaveParticleBindingEnergies);
+  TrySetPar(SaveBoundParticleProperties);
+  TrySetPar(SaveBoundParticleBindingEnergies);
   TrySetPar(MergeTrappedSubhalos);
   TrySetPar(MajorProgenitorMassRatio);
   TrySetPar(BoundMassPrecision);
@@ -294,8 +294,8 @@ void Parameter_t::BroadCast(MpiWorker_t &world, int root)
   _SyncBool(ParticleIdRankStyle);
   _SyncBool(ParticleIdNeedHash);
   _SyncBool(SnapshotIdUnsigned);
-  _SyncBool(SaveSubParticleProperties);
-  _SyncBool(SaveParticleBindingEnergies);
+  _SyncBool(SaveBoundParticleProperties);
+  _SyncBool(SaveBoundParticleBindingEnergies);
   _SyncBool(MergeTrappedSubhalos);
   _SyncVec(SnapshotIdList, MPI_INT);
   world.SyncVectorString(SnapshotNameList, root);
@@ -400,8 +400,8 @@ void Parameter_t::DumpParameters()
   DumpPar(ParticleIdRankStyle);
   DumpPar(ParticleIdNeedHash);
   DumpPar(SnapshotIdUnsigned);
-  DumpPar(SaveSubParticleProperties);
-  DumpPar(SaveParticleBindingEnergies);
+  DumpPar(SaveBoundParticleProperties);
+  DumpPar(SaveBoundParticleBindingEnergies);
 #ifndef DM_ONLY
   DumpPar(ParticlesSplit);
 #endif

--- a/src/config_parser.h
+++ b/src/config_parser.h
@@ -55,8 +55,8 @@ public:
   bool ParticleIdRankStyle; // performance related; load particleId as id ranks. not implemented yet.
   bool ParticleIdNeedHash;  // performance related; disabled if ParticleIdRankStyle is true
   bool SnapshotIdUnsigned;
-  bool SaveSubParticleProperties;
-  bool SaveParticleBindingEnergies;
+  bool SaveBoundParticleProperties;
+  bool SaveBoundParticleBindingEnergies;
   bool MergeTrappedSubhalos; // whether to MergeTrappedSubhalos, see code paper for more info.
   vector<int> SnapshotIdList;
   vector<int> TracerParticleTypes;
@@ -108,8 +108,8 @@ public:
     ParticleIdRankStyle = false; // to be removed
     ParticleIdNeedHash = true;
     SnapshotIdUnsigned = false;
-    SaveSubParticleProperties = false;
-    SaveParticleBindingEnergies = false;
+    SaveBoundParticleProperties = false;
+    SaveBoundParticleBindingEnergies = false;
 #ifdef NO_STRIPPING
     MergeTrappedSubhalos = false;
 #else

--- a/src/config_parser.h
+++ b/src/config_parser.h
@@ -56,6 +56,7 @@ public:
   bool ParticleIdNeedHash;  // performance related; disabled if ParticleIdRankStyle is true
   bool SnapshotIdUnsigned;
   bool SaveSubParticleProperties;
+  bool SaveParticleBindingEnergies;
   bool MergeTrappedSubhalos; // whether to MergeTrappedSubhalos, see code paper for more info.
   vector<int> SnapshotIdList;
   vector<int> TracerParticleTypes;
@@ -108,6 +109,7 @@ public:
     ParticleIdNeedHash = true;
     SnapshotIdUnsigned = false;
     SaveSubParticleProperties = false;
+    SaveParticleBindingEnergies = false;
 #ifdef NO_STRIPPING
     MergeTrappedSubhalos = false;
 #else

--- a/src/io/subhalo_io.cpp
+++ b/src/io/subhalo_io.cpp
@@ -453,10 +453,14 @@ void SubhaloSnapshot_t::WriteBoundSubfile(int iFile, int nfiles, HBTInt NumSubsA
     {
       vl[i].len = Subhalos[i].Nbound;
       vl[i].p = Subhalos[i].ParticleBindingEnergies.data();
+
+      /* Clear the vector to reduce memory footprint and because it will be overwritten anyway. */
+      Subhalos[i].ParticleBindingEnergies.clear();
     }
     writeHDFmatrix(file, vl.data(), "BindingEnergies", ndim, dim_sub, H5T_FloatArr);
     H5Tclose(H5T_FloatArr);
   }
+
   vector<HBTInt> IdBuffer;
   {
     HBTInt NumberOfParticles = 0;

--- a/src/io/subhalo_io.cpp
+++ b/src/io/subhalo_io.cpp
@@ -452,7 +452,7 @@ void SubhaloSnapshot_t::WriteBoundSubfile(int iFile, int nfiles, HBTInt NumSubsA
     for (HBTInt i = 0; i < vl.size(); i++)
     {
       vl[i].len = Subhalos[i].Nbound;
-      vl[i].p = Subhalos[i].Energies.data();
+      vl[i].p = Subhalos[i].ParticleBindingEnergies.data();
     }
     writeHDFmatrix(file, vl.data(), "BindingEnergies", ndim, dim_sub, H5T_FloatArr);
     H5Tclose(H5T_FloatArr);

--- a/src/io/subhalo_io.cpp
+++ b/src/io/subhalo_io.cpp
@@ -372,7 +372,7 @@ void SubhaloSnapshot_t::WriteBoundSubfile(int iFile, int nfiles, HBTInt NumSubsA
   vector<hvl_t> vl(Subhalos.size());
   hsize_t dim_sub[] = {Subhalos.size()};
   // now write the particle list for each subhalo
-  if (HBTConfig.SaveSubParticleProperties)
+  if (HBTConfig.SaveBoundParticleProperties)
   {
     hid_t H5T_ParticleInMem = H5Tcreate(H5T_COMPOUND, sizeof(Particle_t));
     hsize_t dim_xyz = 3;
@@ -423,7 +423,7 @@ void SubhaloSnapshot_t::WriteBoundSubfile(int iFile, int nfiles, HBTInt NumSubsA
   H5LTset_attribute_string(file, "/NestedSubhalos", "Comment",
                            "List of the TrackIds of first-level sub-subhaloes within each subhalo.");
 
-  if (HBTConfig.SaveParticleBindingEnergies)
+  if (HBTConfig.SaveBoundParticleBindingEnergies)
   {
     hid_t H5T_FloatArr = H5Tvlen_create(H5T_NATIVE_FLOAT);
     for (HBTInt i = 0; i < vl.size(); i++)

--- a/src/io/subhalo_io.cpp
+++ b/src/io/subhalo_io.cpp
@@ -263,29 +263,6 @@ void SubhaloSnapshot_t::ReadFile(int iFile, const SubReaderDepth_t depth)
       ReclaimVlenData(dset, H5T_HBTIntArr, vl.data());
       H5Dclose(dset);
     }
-
-    /* NOTE: disabled for now because I am unsure of why we should re-read the binding
-     * energy array if we will overwrite it in Subhalo::Unbind. I do not clear out the vector here,
-     * since I already do that after saving the energies in the previous output. */
-
-// #ifdef SAVE_BINDING_ENERGY
-//     { // read binding energies
-//       dset = H5Dopen2(file, "BindingEnergies", H5P_DEFAULT);
-//       GetDatasetDims(dset, dims);
-//       assert(dims[0] == nsubhalos);
-//       hid_t H5T_FloatArr = H5Tvlen_create(H5T_NATIVE_FLOAT);
-//       H5Dread(dset, H5T_FloatArr, H5S_ALL, H5S_ALL, H5P_DEFAULT, vl.data());
-//       for (HBTInt i = 0; i < nsubhalos; i++)
-//       {
-//         NewSubhalos[i].Energies.resize(vl[i].len);
-//         memcpy(NewSubhalos[i].Energies.data(), vl[i].p, sizeof(float) * vl[i].len);
-//       }
-//       ReclaimVlenData(dset, H5T_FloatArr, vl.data());
-//       H5Tclose(H5T_FloatArr);
-//       H5Dclose(dset);
-//     }
-// #endif
-//
     H5Tclose(H5T_HBTIntArr);
   }
 

--- a/src/io/subhalo_io.cpp
+++ b/src/io/subhalo_io.cpp
@@ -264,24 +264,28 @@ void SubhaloSnapshot_t::ReadFile(int iFile, const SubReaderDepth_t depth)
       H5Dclose(dset);
     }
 
-#ifdef SAVE_BINDING_ENERGY
-    { // read binding energies
-      dset = H5Dopen2(file, "BindingEnergies", H5P_DEFAULT);
-      GetDatasetDims(dset, dims);
-      assert(dims[0] == nsubhalos);
-      hid_t H5T_FloatArr = H5Tvlen_create(H5T_NATIVE_FLOAT);
-      H5Dread(dset, H5T_FloatArr, H5S_ALL, H5S_ALL, H5P_DEFAULT, vl.data());
-      for (HBTInt i = 0; i < nsubhalos; i++)
-      {
-        NewSubhalos[i].Energies.resize(vl[i].len);
-        memcpy(NewSubhalos[i].Energies.data(), vl[i].p, sizeof(float) * vl[i].len);
-      }
-      ReclaimVlenData(dset, H5T_FloatArr, vl.data());
-      H5Tclose(H5T_FloatArr);
-      H5Dclose(dset);
-    }
-#endif
+    /* NOTE: disabled for now because I am unsure of why we should re-read the binding
+     * energy array if we will overwrite it in Subhalo::Unbind. I do not clear out the vector here,
+     * since I already do that after saving the energies in the previous output. */
 
+// #ifdef SAVE_BINDING_ENERGY
+//     { // read binding energies
+//       dset = H5Dopen2(file, "BindingEnergies", H5P_DEFAULT);
+//       GetDatasetDims(dset, dims);
+//       assert(dims[0] == nsubhalos);
+//       hid_t H5T_FloatArr = H5Tvlen_create(H5T_NATIVE_FLOAT);
+//       H5Dread(dset, H5T_FloatArr, H5S_ALL, H5S_ALL, H5P_DEFAULT, vl.data());
+//       for (HBTInt i = 0; i < nsubhalos; i++)
+//       {
+//         NewSubhalos[i].Energies.resize(vl[i].len);
+//         memcpy(NewSubhalos[i].Energies.data(), vl[i].p, sizeof(float) * vl[i].len);
+//       }
+//       ReclaimVlenData(dset, H5T_FloatArr, vl.data());
+//       H5Tclose(H5T_FloatArr);
+//       H5Dclose(dset);
+//     }
+// #endif
+//
     H5Tclose(H5T_HBTIntArr);
   }
 
@@ -442,17 +446,17 @@ void SubhaloSnapshot_t::WriteBoundSubfile(int iFile, int nfiles, HBTInt NumSubsA
   H5LTset_attribute_string(file, "/NestedSubhalos", "Comment",
                            "List of the TrackIds of first-level sub-subhaloes within each subhalo.");
 
-#ifdef SAVE_BINDING_ENERGY
-  hid_t H5T_FloatArr = H5Tvlen_create(H5T_NATIVE_FLOAT);
-  for (HBTInt i = 0; i < vl.size(); i++)
+  if (HBTConfig.SaveParticleBindingEnergies)
   {
-    vl[i].len = Subhalos[i].Nbound;
-    vl[i].p = Subhalos[i].Energies.data();
+    hid_t H5T_FloatArr = H5Tvlen_create(H5T_NATIVE_FLOAT);
+    for (HBTInt i = 0; i < vl.size(); i++)
+    {
+      vl[i].len = Subhalos[i].Nbound;
+      vl[i].p = Subhalos[i].Energies.data();
+    }
+    writeHDFmatrix(file, vl.data(), "BindingEnergies", ndim, dim_sub, H5T_FloatArr);
+    H5Tclose(H5T_FloatArr);
   }
-  writeHDFmatrix(file, vl.data(), "BindingEnergies", ndim, dim_sub, H5T_FloatArr);
-  H5Tclose(H5T_FloatArr);
-#endif
-
   vector<HBTInt> IdBuffer;
   {
     HBTInt NumberOfParticles = 0;

--- a/src/subhalo.h
+++ b/src/subhalo.h
@@ -97,7 +97,10 @@ public:
 
   ParticleList_t Particles;
 
-  vector<float> Energies; /* Binding energies of the particles bound to the subhalo */
+  /* Binding energies of the particles bound to the subhalo. It is a separate instance from ParticleList_t
+   * because it does not need communicating before unbinding. */
+  vector<float> ParticleBindindingEnergies; 
+
   SubIdList_t NestedSubhalos; // list of sub-in-subs.
 
   /* Methods relating to new merging approach */

--- a/src/subhalo.h
+++ b/src/subhalo.h
@@ -99,7 +99,7 @@ public:
 
   /* Binding energies of the particles bound to the subhalo. It is a separate instance from ParticleList_t
    * because it does not need communicating before unbinding. */
-  vector<float> ParticleBindindingEnergies; 
+  vector<float> ParticleBindingEnergies; 
 
   SubIdList_t NestedSubhalos; // list of sub-in-subs.
 

--- a/src/subhalo.h
+++ b/src/subhalo.h
@@ -96,9 +96,8 @@ public:
   HBTInt NestedParentTrackId; // the trackID of the subhalo containing this subhalo, or -1 for top level subhalos
 
   ParticleList_t Particles;
-#ifdef SAVE_BINDING_ENERGY
-  vector<float> Energies;
-#endif
+
+  vector<float> Energies; /* Binding energies of the particles bound to the subhalo */
   SubIdList_t NestedSubhalos; // list of sub-in-subs.
 
   /* Methods relating to new merging approach */

--- a/src/subhalo_unbind.cpp
+++ b/src/subhalo_unbind.cpp
@@ -484,7 +484,6 @@ void Subhalo_t::Unbind(const Snapshot_t &epoch)
 #pragma omp parallel for if (Nbound > 100)
     for (HBTInt i = 0; i < Nbound; i++)
       Energies[i] = Elist[i].E;
-#endif
   }
 
 }

--- a/src/subhalo_unbind.cpp
+++ b/src/subhalo_unbind.cpp
@@ -290,7 +290,7 @@ void Subhalo_t::Unbind(const Snapshot_t &epoch)
     GetCorePhaseSpaceProperties();
 
     /* No bound particles, hence zero binding energies will be saved */
-    if(HBTConfig.SaveParticleBindingEnergies)
+    if(HBTConfig.SaveBoundParticleBindingEnergies)
       ParticleBindingEnergies.clear();
 
     return;
@@ -484,7 +484,7 @@ void Subhalo_t::Unbind(const Snapshot_t &epoch)
   GetCorePhaseSpaceProperties();
 
   /* Store the binding energy information to save later */
-  if(HBTConfig.SaveParticleBindingEnergies)
+  if(HBTConfig.SaveBoundParticleBindingEnergies)
   {
     ParticleBindingEnergies.resize(Nbound);
 #pragma omp parallel for if (Nbound > 100)

--- a/src/subhalo_unbind.cpp
+++ b/src/subhalo_unbind.cpp
@@ -291,7 +291,7 @@ void Subhalo_t::Unbind(const Snapshot_t &epoch)
 
     /* No bound particles, hence zero binding energies will be saved */
     if(HBTConfig.SaveParticleBindingEnergies)
-      Energies.clear();
+      ParticleBindingEnergies.clear();
 
     return;
   }
@@ -480,10 +480,10 @@ void Subhalo_t::Unbind(const Snapshot_t &epoch)
   /* Store the binding energy information to save later */
   if(HBTConfig.SaveParticleBindingEnergies)
   {
-    Energies.resize(Nbound);
+    ParticleBindingEnergies.resize(Nbound);
 #pragma omp parallel for if (Nbound > 100)
     for (HBTInt i = 0; i < Nbound; i++)
-      Energies[i] = Elist[i].E;
+      ParticleBindingEnergies[i] = Elist[i].E;
   }
 
 }

--- a/src/subhalo_unbind.cpp
+++ b/src/subhalo_unbind.cpp
@@ -481,7 +481,7 @@ void Subhalo_t::Unbind(const Snapshot_t &epoch)
   if(HBTConfig.SaveParticleBindingEnergies)
   {
     Energies.resize(Nbound);
-#pragma omp paralle for if (Nbound > 100)
+#pragma omp parallel for if (Nbound > 100)
     for (HBTInt i = 0; i < Nbound; i++)
       Energies[i] = Elist[i].E;
 #endif

--- a/src/subhalo_unbind.cpp
+++ b/src/subhalo_unbind.cpp
@@ -288,9 +288,11 @@ void Subhalo_t::Unbind(const Snapshot_t &epoch)
     Nbound = Particles.size();
     CountParticles();
     GetCorePhaseSpaceProperties();
-#ifdef SAVE_BINDING_ENERGY
-    Energies.clear();
-#endif
+
+    /* No bound particles, hence zero binding energies will be saved */
+    if(HBTConfig.SaveParticleBindingEnergies)
+      Energies.clear();
+
     return;
   }
 
@@ -475,12 +477,16 @@ void Subhalo_t::Unbind(const Snapshot_t &epoch)
 
   GetCorePhaseSpaceProperties();
 
-#ifdef SAVE_BINDING_ENERGY
-  Energies.resize(Nbound);
+  /* Store the binding energy information to save later */
+  if(HBTConfig.SaveParticleBindingEnergies)
+  {
+    Energies.resize(Nbound);
 #pragma omp paralle for if (Nbound > 100)
-  for (HBTInt i = 0; i < Nbound; i++)
-    Energies[i] = Elist[i].E;
+    for (HBTInt i = 0; i < Nbound; i++)
+      Energies[i] = Elist[i].E;
 #endif
+  }
+
 }
 void Subhalo_t::RecursiveUnbind(SubhaloList_t &Subhalos, const Snapshot_t &snap)
 {

--- a/src/subhalo_unbind.cpp
+++ b/src/subhalo_unbind.cpp
@@ -310,6 +310,10 @@ void Subhalo_t::Unbind(const Snapshot_t &epoch)
    * prevents accessing entries beyond the corresponding particle array. */
   SetTracerIndex(0);
 
+  /* Variables that store the centre of mass reference frame, which is used during
+   * unbinding. In the first iteration, the centre of mass reference frame is that
+   * of all particles associated to the subhalo in the previous output. Subsequent
+   * iterations use the centre of mass frame of particles identified as bound. */
   HBTxyz OldRefPos, OldRefVel;
   auto &RefPos = ComovingAveragePosition;
   auto &RefVel = PhysicalAverageVelocity;
@@ -430,8 +434,11 @@ void Subhalo_t::Unbind(const Snapshot_t &epoch)
           copyHBTxyz(OldRefVel, RefVel);
         }
       }
+
+      /* The centre of mass frame is updated here */
       Mbound = ESnap.AverageVelocity(PhysicalAverageVelocity, Nbound);
       ESnap.AveragePosition(ComovingAveragePosition, Nbound);
+
       if (Nbound >= Nlast * BoundMassPrecision) // converge
       {
         if (!IsAlive())

--- a/src/subhalo_unbind.cpp
+++ b/src/subhalo_unbind.cpp
@@ -345,7 +345,6 @@ void Subhalo_t::Unbind(const Snapshot_t &epoch)
         HBTxyz OldVel;
         epoch.RelativeVelocity(x, v, OldRefPos, OldRefVel, OldVel);
         Elist[i].E += VecDot(OldVel, RefVelDiff) + dK - tree.EvaluatePotential(x, 0);
-        ;
       }
       Nlast = Nbound;
     }

--- a/testing/config_test.txt
+++ b/testing/config_test.txt
@@ -35,10 +35,10 @@ MaxSampleSizeOfPotentialEstimate 0
 
 # Test simulation does not provide splitting information
 ParticlesSplit 0
-SaveParticleBindingEnergies 1
+SaveBoundParticleBindingEnergies 1
 
 # Optional parameters; default values are shown here
 #MinNumPartOfSub 20
 #PeriodicBoundaryOn 1
-#SaveSubParticleProperties 0
+#SaveBoundParticleProperties 0
 #TracerParticleTypes 1 4 

--- a/testing/config_test.txt
+++ b/testing/config_test.txt
@@ -35,6 +35,7 @@ MaxSampleSizeOfPotentialEstimate 0
 
 # Test simulation does not provide splitting information
 ParticlesSplit 0
+SaveParticleBindindingEnergies 1
 
 # Optional parameters; default values are shown here
 #MinNumPartOfSub 20

--- a/testing/config_test.txt
+++ b/testing/config_test.txt
@@ -35,7 +35,7 @@ MaxSampleSizeOfPotentialEstimate 0
 
 # Test simulation does not provide splitting information
 ParticlesSplit 0
-SaveParticleBindindingEnergies 1
+SaveParticleBindingEnergies 1
 
 # Optional parameters; default values are shown here
 #MinNumPartOfSub 20

--- a/toolbox/swiftsim/pipeline/templates/template_config.txt
+++ b/toolbox/swiftsim/pipeline/templates/template_config.txt
@@ -24,3 +24,6 @@ VelInKmS -1
 MinNumPartOfSub 20
 TracerParticleTypes 1 4
 MinNumTracerPartOfSub 10
+
+[Additional information]
+SaveBoundParticleBindingEnergies 1


### PR DESCRIPTION
Some COLIBRE projects require the binding energy of the particles bound to subhalos. This PR will add the option for HBT to output this information, as it is already calculated internally.

Note that this option existed in the past (SAVE_BINDING_ENERGIES), but it was not made available within the cmake compilation step. After some discussion, we decided to add the option as a runtime option.